### PR TITLE
Add comprehensive XAML value converters and tests

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,5 +1,4 @@
 using Nuke.Common;
-using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/global.json
+++ b/global.json
@@ -1,9 +1,0 @@
-{
-    "sdk": {
-        "version": "8.0.10",
-        "rollForward": "latestMinor"
-    },
-    "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "3.0.44"
-    }
-}

--- a/src/XamlConverters.TestApp/XamlConverters.TestApp.csproj
+++ b/src/XamlConverters.TestApp/XamlConverters.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>

--- a/src/XamlConverters.Tests/ArithmeticConverterTests.cs
+++ b/src/XamlConverters.Tests/ArithmeticConverterTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters.Tests;
+
+/// <summary>
+/// ArithmeticConverterTests.
+/// </summary>
+public class ArithmeticConverterTests
+{
+    /// <summary>
+    /// Performses the arithmetic.
+    /// </summary>
+    /// <param name="input">The input.</param>
+    /// <param name="param">The parameter.</param>
+    /// <param name="expected">The expected.</param>
+    [Theory]
+    [InlineData(10, "+5", 15)]
+    [InlineData(10, "- 3", 7)]
+    [InlineData(10, "*2", 20)]
+    [InlineData(10, "/2", 5)]
+    public void PerformsArithmetic(int input, string param, double expected)
+    {
+        var c = new ArithmeticConverter();
+        var result = ((IValueConverter)c).Convert(input, typeof(double), param, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(expected, (double)result, 5);
+    }
+}

--- a/src/XamlConverters.Tests/BoolToVisibilityAdvancedConverterTests.cs
+++ b/src/XamlConverters.Tests/BoolToVisibilityAdvancedConverterTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+public class BoolToVisibilityAdvancedConverterTests
+{
+    [Fact]
+    public void TrueVisible()
+    {
+        var c = new BoolToVisibilityAdvancedConverter();
+        var result = c.Convert(true, typeof(Visibility), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(Visibility.Visible, result);
+    }
+
+    [Fact]
+    public void FalseCollapsed()
+    {
+        var c = new BoolToVisibilityAdvancedConverter();
+        var result = c.Convert(false, typeof(Visibility), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(Visibility.Collapsed, result);
+    }
+
+    [Fact]
+    public void FalseHiddenWhenH()
+    {
+        var c = new BoolToVisibilityAdvancedConverter();
+        var result = c.Convert(false, typeof(Visibility), "H", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(Visibility.Hidden, result);
+    }
+}

--- a/src/XamlConverters.Tests/BoolToVisibilityConverterTests.cs
+++ b/src/XamlConverters.Tests/BoolToVisibilityConverterTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+public class BoolToVisibilityConverterTests
+{
+    [Theory]
+    [InlineData(true, Visibility.Visible)]
+    [InlineData(false, Visibility.Collapsed)]
+    public void ConvertsBoolToVisibility(bool input, Visibility expected)
+    {
+        var c = new BoolToVisibilityConverter();
+        var result = c.Convert(input, typeof(Visibility), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(true, Visibility.Collapsed)]
+    [InlineData(false, Visibility.Visible)]
+    public void ConvertsBoolToVisibility_Inverted(bool input, Visibility expected)
+    {
+        var c = new BoolToVisibilityConverter();
+        var result = c.Convert(input, typeof(Visibility), "reverse", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/XamlConverters.Tests/CP.Xaml.Converters.Tests.csproj
+++ b/src/XamlConverters.Tests/CP.Xaml.Converters.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net462;net8.0-windows;net9.0-windows</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- Suppress style/documentation rules for tests -->
+    <NoWarn>SA1600;SA1402;SA1502;SA1136;SA1602;SA1512;SA1513</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\XamlConverters\CP.Xaml.Converters.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/XamlConverters.Tests/ComparisonConverterTests.cs
+++ b/src/XamlConverters.Tests/ComparisonConverterTests.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+public class ComparisonConverterTests
+{
+    [Theory]
+    [InlineData(5, ">3", true)]
+    [InlineData(3, ">3", false)]
+    [InlineData(3, ">=3", true)]
+    [InlineData(2, "<3", true)]
+    [InlineData(2, "!=3", true)]
+    [InlineData(3, "!=3", false)]
+    [InlineData(3, "!>=3", false)] // inverted of >=3
+    public void ComparesValues(object value, string param, bool expected)
+    {
+        var c = new ComparisonConverter();
+        var result = c.Convert(value, typeof(bool), param, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/XamlConverters.Tests/CountConvertersTests.cs
+++ b/src/XamlConverters.Tests/CountConvertersTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+public class CountConvertersTests
+{
+    [Fact]
+    public void CountToBoolean_GreaterThanZero()
+    {
+        var c = new CountToBooleanConverter();
+        var result = c.Convert(new List<int> { 1, 2 }, typeof(bool), ">0", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.True((bool)result);
+    }
+
+    [Fact]
+    public void CountToVisibility_EqualsZeroCollapsed()
+    {
+        var c = new CountToVisibilityConverter();
+        var result = c.Convert(Enumerable.Empty<int>(), typeof(Visibility), "==0", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(Visibility.Visible, result); // Visible because ==0 satisfied
+    }
+}

--- a/src/XamlConverters.Tests/EnumToBooleanConverterTests.cs
+++ b/src/XamlConverters.Tests/EnumToBooleanConverterTests.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+public enum TestState { One, Two }
+
+public class EnumToBooleanConverterTests
+{
+    [Theory]
+    [InlineData(TestState.One, "One", true)]
+    [InlineData(TestState.One, "Two", false)]
+    public void EnumMatches(TestState state, string param, bool expected)
+    {
+        var c = new EnumToBooleanConverter();
+        var result = c.Convert(state, typeof(bool), param, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/XamlConverters.Tests/MathConverterTests.cs
+++ b/src/XamlConverters.Tests/MathConverterTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+/// <summary>
+/// MathConverterTests.
+/// </summary>
+public class MathConverterTests
+{
+    /// <summary>
+    /// Evaluateses the expression.
+    /// </summary>
+    [Fact]
+    public void EvaluatesExpression()
+    {
+        var c = new MathConverter();
+        var result = c.Convert(new object[] { 5, 3 }, typeof(double), "{0}+{1}*2", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(11d, (double)result, 5);
+    }
+}

--- a/src/XamlConverters.Tests/MultiBooleanConvertersTests.cs
+++ b/src/XamlConverters.Tests/MultiBooleanConvertersTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+/// <summary>
+/// MultiBooleanConvertersTests.
+/// </summary>
+public class MultiBooleanConvertersTests
+{
+    /// <summary>
+    /// Ands all true returns true.
+    /// </summary>
+    [Fact]
+    public void And_AllTrue_ReturnsTrue()
+    {
+        var c = new MultiBooleanAndConverter();
+        var result = c.Convert(new object[] { true, true, true }, typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.True((bool)result);
+    }
+
+    /// <summary>
+    /// Ands the one false returns false.
+    /// </summary>
+    [Fact]
+    public void And_OneFalse_ReturnsFalse()
+    {
+        var c = new MultiBooleanAndConverter();
+        var result = c.Convert(new object[] { true, false, true }, typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.False((bool)result);
+    }
+
+    /// <summary>
+    /// Ors any true returns true.
+    /// </summary>
+    [Fact]
+    public void Or_AnyTrue_ReturnsTrue()
+    {
+        var c = new MultiBooleanOrConverter();
+        var result = c.Convert(new object[] { false, false, true }, typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.True((bool)result);
+    }
+
+    /// <summary>
+    /// Ors all false returns false.
+    /// </summary>
+    [Fact]
+    public void Or_AllFalse_ReturnsFalse()
+    {
+        var c = new MultiBooleanOrConverter();
+        var result = c.Convert(new object[] { false, false }, typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.False((bool)result);
+    }
+
+    /// <summary>
+    /// Xors the odd true returns true.
+    /// </summary>
+    [Fact]
+    public void Xor_OddTrue_ReturnsTrue()
+    {
+        var c = new BooleanXorConverter();
+        var result = c.Convert(new object[] { true, false, true }, typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.False((bool)result); // two trues -> even -> false
+    }
+
+    /// <summary>
+    /// Xors the single true returns true.
+    /// </summary>
+    [Fact]
+    public void Xor_SingleTrue_ReturnsTrue()
+    {
+        var c = new BooleanXorConverter();
+        var result = c.Convert(new object[] { true, false, false }, typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.True((bool)result);
+    }
+}

--- a/src/XamlConverters.Tests/NullCoalesceConverterTests.cs
+++ b/src/XamlConverters.Tests/NullCoalesceConverterTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+public class NullCoalesceConverterTests
+{
+    [Fact]
+    public void ReturnsParameterIfNull()
+    {
+        var c = new NullCoalesceConverter();
+        var result = c.Convert(null!, typeof(string), "fallback", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal("fallback", result);
+    }
+
+    [Fact]
+    public void ReturnsValueIfNotNull()
+    {
+        var c = new NullCoalesceConverter();
+        var result = c.Convert("value", typeof(string), "fallback", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal("value", result);
+    }
+}

--- a/src/XamlConverters.Tests/PercentageConverterTests.cs
+++ b/src/XamlConverters.Tests/PercentageConverterTests.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+public class PercentageConverterTests
+{
+    [Theory]
+    [InlineData(200, "50%", 100)]
+    [InlineData(10, "0.5", 5)]
+    public void AppliesPercentage(double input, string param, double expected)
+    {
+        var c = new PercentageConverter();
+        var result = c.Convert(input, typeof(double), param, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(expected, (double)result, 5);
+    }
+}

--- a/src/XamlConverters.Tests/StringNullOrEmptyToBoolConverterTests.cs
+++ b/src/XamlConverters.Tests/StringNullOrEmptyToBoolConverterTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+/// <summary>
+/// StringNullOrEmptyToBoolConverterTests.
+/// </summary>
+public class StringNullOrEmptyToBoolConverterTests
+{
+    /// <summary>
+    /// Detectses the null or empty.
+    /// </summary>
+    /// <param name="input">The input.</param>
+    /// <param name="expected">if set to <c>true</c> [expected].</param>
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("abc", false)]
+    public void DetectsNullOrEmpty(string? input, bool expected)
+    {
+        var c = new StringNullOrEmptyToBoolConverter();
+        var result = c.Convert(input!, typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// Invertses the specified input.
+    /// </summary>
+    /// <param name="input">The input.</param>
+    /// <param name="expected">if set to <c>true</c> [expected].</param>
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("abc", true)]
+    public void Inverts(string? input, bool expected)
+    {
+        var c = new StringNullOrEmptyToBoolConverter();
+        var result = c.Convert(input!, typeof(bool), "invert", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/XamlConverters.Tests/ThicknessUniformConverterTests.cs
+++ b/src/XamlConverters.Tests/ThicknessUniformConverterTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+public class ThicknessUniformConverterTests
+{
+    [Fact]
+    public void AllSides()
+    {
+        var c = new ThicknessUniformConverter();
+        var t = (Thickness)c.Convert(5, typeof(Thickness), null!, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(new Thickness(5), t);
+    }
+
+    [Fact]
+    public void HorizontalOnly()
+    {
+        var c = new ThicknessUniformConverter();
+        var t = (Thickness)c.Convert(3, typeof(Thickness), "H", System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(3, t.Left);
+        Assert.Equal(3, t.Right);
+        Assert.Equal(0, t.Top);
+        Assert.Equal(0, t.Bottom);
+    }
+}

--- a/src/XamlConverters.Tests/Usings.cs
+++ b/src/XamlConverters.Tests/Usings.cs
@@ -1,0 +1,5 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+global using System.Windows;
+global using Xunit;

--- a/src/XamlConverters.sln
+++ b/src/XamlConverters.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.8.34408.163
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11010.61 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CP.Xaml.Converters", "XamlConverters\CP.Xaml.Converters.csproj", "{E1490765-4B9F-4280-A695-59C2310C6E81}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{2919E5AB-258E-438C-9B6C-C20281B46A3A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XamlConverters.TestApp", "XamlConverters.TestApp\XamlConverters.TestApp.csproj", "{735F691C-B86E-4371-8153-9750352A90D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CP.Xaml.Converters.Tests", "XamlConverters.Tests\CP.Xaml.Converters.Tests.csproj", "{DEE0F2C9-BACC-A89A-F705-707F90BD1129}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,6 +27,10 @@ Global
 		{735F691C-B86E-4371-8153-9750352A90D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{735F691C-B86E-4371-8153-9750352A90D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{735F691C-B86E-4371-8153-9750352A90D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEE0F2C9-BACC-A89A-F705-707F90BD1129}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEE0F2C9-BACC-A89A-F705-707F90BD1129}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEE0F2C9-BACC-A89A-F705-707F90BD1129}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEE0F2C9-BACC-A89A-F705-707F90BD1129}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/XamlConverters/Boolean/BooleanXorConverter.cs
+++ b/src/XamlConverters/Boolean/BooleanXorConverter.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Multi-binding XOR converter: true if an odd number of inputs are true.
+/// </summary>
+public sealed class BooleanXorConverter : IMultiValueConverter
+{
+    /// <summary>
+    /// Converts source values to a value for the binding target. The data binding engine calls this method when it propagates the values from source bindings to the binding target.
+    /// </summary>
+    /// <param name="values">The array of values that the source bindings in the <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to provide for conversion.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value.If the method returns null, the valid null value is used.A return value of <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the converter did not produce a value, and that the binding will use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default value.A return value of <see cref="T:System.Windows.Data.Binding" />.<see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
+    /// </returns>
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        var count = 0;
+        foreach (var v in values)
+        {
+            if (v == DependencyProperty.UnsetValue)
+            {
+                continue;
+            }
+
+            if (v is bool b && b)
+            {
+                count++;
+            }
+        }
+
+        return (count % 2) == 1;
+    }
+
+    /// <summary>
+    /// Converts a binding target value to the source binding values.
+    /// </summary>
+    /// <param name="value">The value that the binding target produces.</param>
+    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of values that are suggested for the method to return.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// An array of values that have been converted from the target value back to the source values.
+    /// </returns>
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => [.. targetTypes.Select(_ => Binding.DoNothing)];
+}

--- a/src/XamlConverters/Boolean/EnumToBooleanConverter.cs
+++ b/src/XamlConverters/Boolean/EnumToBooleanConverter.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Converts between an Enum value and a boolean for e.g. RadioButton binding.
+/// Parameter must be the Enum member name.
+/// </summary>
+public sealed class EnumToBooleanConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value produced by the binding source.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+        {
+            return false;
+        }
+
+        return string.Equals(value.ToString(), parameter.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (parameter == null)
+        {
+            return Binding.DoNothing;
+        }
+
+        if (value is bool b && b)
+        {
+            return Enum.Parse(targetType, parameter.ToString()!, ignoreCase: true);
+        }
+
+        return Binding.DoNothing;
+    }
+}

--- a/src/XamlConverters/Boolean/MultiBooleanAndConverter.cs
+++ b/src/XamlConverters/Boolean/MultiBooleanAndConverter.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Multi-binding converter that returns true only if ALL inputs are true. Parameter "invert" to invert final result.
+/// </summary>
+public sealed class MultiBooleanAndConverter : IMultiValueConverter
+{
+    /// <summary>
+    /// Aggregates values using logical AND.
+    /// </summary>
+    /// <param name="values">Source values.</param>
+    /// <param name="targetType">Target type.</param>
+    /// <param name="parameter">Optional parameter (invert).</param>
+    /// <param name="culture">Culture info.</param>
+    /// <returns>True when all are true (optionally inverted).</returns>
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        var result = true;
+        foreach (var v in values)
+        {
+            if (v == DependencyProperty.UnsetValue)
+            {
+                continue; // skip uninitialized
+            }
+
+            if (v is bool b)
+            {
+                if (!b)
+                {
+                    result = false;
+                    break;
+                }
+            }
+            else if (v == null)
+            {
+                result = false;
+                break;
+            }
+        }
+
+        var invert = parameter?.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true;
+        return invert ? !result : result;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">Ignored.</param>
+    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of values that are suggested for the method to return.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// Array of DoNothing.
+    /// </returns>
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => targetTypes.Select(t => Binding.DoNothing).ToArray();
+}

--- a/src/XamlConverters/Boolean/MultiBooleanOrConverter.cs
+++ b/src/XamlConverters/Boolean/MultiBooleanOrConverter.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Multi-binding converter that returns true if ANY input is true. Parameter "invert" to invert final result.
+/// </summary>
+public sealed class MultiBooleanOrConverter : IMultiValueConverter
+{
+    /// <summary>
+    /// Aggregates values using logical OR.
+    /// </summary>
+    /// <param name="values">The array of values that the source bindings in the <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to provide for conversion.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value.If the method returns null, the valid null value is used.A return value of <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the converter did not produce a value, and that the binding will use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default value.A return value of <see cref="T:System.Windows.Data.Binding" />.<see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">values.</exception>
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        var result = false;
+        foreach (var v in values)
+        {
+            if (v == DependencyProperty.UnsetValue)
+            {
+                continue;
+            }
+
+            if (v is bool b && b)
+            {
+                result = true;
+                break;
+            }
+        }
+
+        var invert = parameter?.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true;
+        return invert ? !result : result;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">The value that the binding target produces.</param>
+    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of values that are suggested for the method to return.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// An array of values that have been converted from the target value back to the source values.
+    /// </returns>
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => targetTypes.Select(t => Binding.DoNothing).ToArray();
+}

--- a/src/XamlConverters/Boolean/StringNullOrEmptyToBoolConverter.cs
+++ b/src/XamlConverters/Boolean/StringNullOrEmptyToBoolConverter.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Converts a string to a boolean indicating whether it is (or is not) null/empty.
+/// Optional parameter: "invert" (or "true") to invert the result.
+/// </summary>
+public sealed class StringNullOrEmptyToBoolConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts the string value to a boolean indicating IsNullOrEmpty.
+    /// </summary>
+    /// <param name="value">The bound value.</param>
+    /// <param name="targetType">The target type.</param>
+    /// <param name="parameter">Optional parameter: invert.</param>
+    /// <param name="culture">Culture info.</param>
+    /// <returns>True if (possibly inverted) condition met.</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var isNullOrEmpty = string.IsNullOrEmpty(value as string);
+        var invert = parameter != null && (parameter.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true || parameter.ToString()?.Equals("true", StringComparison.OrdinalIgnoreCase) == true);
+        return invert ? !isNullOrEmpty : isNullOrEmpty;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/CP.Xaml.Converters.csproj
+++ b/src/XamlConverters/CP.Xaml.Converters.csproj
@@ -1,10 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows;net9.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="PolySharp" Version="1.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="IndexRange" Version="1.1.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/XamlConverters/Collections/CountToBooleanConverter.cs
+++ b/src/XamlConverters/Collections/CountToBooleanConverter.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Returns true if collection count satisfies comparison in parameter. Parameter forms: ">0", "==0", "!= 1" etc. Default is >0.
+/// </summary>
+public sealed class CountToBooleanConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value produced by the binding source.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not IEnumerable enumerable)
+        {
+            return false;
+        }
+
+        var count = 0;
+        foreach (var a in enumerable)
+        {
+            count++;
+        }
+
+        var parm = parameter?.ToString();
+        if (string.IsNullOrWhiteSpace(parm))
+        {
+            return count > 0;
+        }
+
+        // reuse ComparisonConverter logic minimally
+        if (!CountComparison.TryParse(parm!, out var cmp))
+        {
+            return count > 0;
+        }
+
+        return cmp.Evaluate(count);
+    }
+
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+
+    private record CountComparison(string Op, int Rhs)
+    {
+        public bool Evaluate(int lhs) => Op switch
+        {
+            ">" => lhs > Rhs,
+            ">=" => lhs >= Rhs,
+            "<" => lhs < Rhs,
+            "<=" => lhs <= Rhs,
+            "==" => lhs == Rhs,
+            "!=" => lhs != Rhs,
+            _ => false
+        };
+
+        public static bool TryParse(string text, out CountComparison cmp)
+        {
+            text = text.Replace(" ", string.Empty);
+            var ops = new[] { ">=", "<=", "==", "!=", ">", "<" };
+            foreach (var op in ops)
+            {
+                var idx = text.IndexOf(op, StringComparison.Ordinal);
+                if (idx >= 0)
+                {
+                    if (int.TryParse(text[(idx + op.Length)..], out var rhs))
+                    {
+                        cmp = new CountComparison(op, rhs);
+                        return true;
+                    }
+                }
+            }
+
+            cmp = null!;
+            return false;
+        }
+    }
+}

--- a/src/XamlConverters/Collections/CountToVisibilityConverter.cs
+++ b/src/XamlConverters/Collections/CountToVisibilityConverter.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Converts collection Count to Visibility using comparison parameter (see CountToBooleanConverter). Optional token 'H' to use Hidden.
+/// </summary>
+public sealed class CountToVisibilityConverter : IValueConverter
+{
+    private readonly CountToBooleanConverter _bool = new();
+
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value produced by the binding source.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var parm = parameter?.ToString() ?? string.Empty;
+        var useHidden = parm.Contains('H');
+        var comparisonPart = parm.Replace("H", string.Empty);
+        var result = (bool)_bool.Convert(value, targetType, string.IsNullOrWhiteSpace(comparisonPart) ? null : comparisonPart, culture);
+        return result ? Visibility.Visible : useHidden ? Visibility.Hidden : Visibility.Collapsed;
+    }
+
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/ConvertersRegistry.cs
+++ b/src/XamlConverters/ConvertersRegistry.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Windows;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Static registry exposing singleton instances for commonly reused stateless converters to reduce XAML noise.
+/// </summary>
+public static class ConvertersRegistry
+{
+    /// <summary>
+    /// The not.
+    /// </summary>
+    public static readonly BoolNegationConverter Not = new();
+    /// <summary>
+    /// The bool to visibility.
+    /// </summary>
+    public static readonly BoolToVisibilityConverter BoolToVisibility = new();
+    /// <summary>
+    /// The bool to visibility adv.
+    /// </summary>
+    public static readonly BoolToVisibilityAdvancedConverter BoolToVisibilityAdv = new();
+    /// <summary>
+    /// The not null to visibility.
+    /// </summary>
+    public static readonly ValueNotNullToVisibilityConverter NotNullToVisibility = new();
+    /// <summary>
+    /// The not null to bool.
+    /// </summary>
+    public static readonly ValueNotNullToBoolConverter NotNullToBool = new();
+    /// <summary>
+    /// The null to bool.
+    /// </summary>
+    public static readonly NullToBoolConverter NullToBool = NullToBoolConverter.NotNull;
+    /// <summary>
+    /// The null coalesce.
+    /// </summary>
+    public static readonly NullCoalesceConverter NullCoalesce = new();
+    /// <summary>
+    /// The invert visibility.
+    /// </summary>
+    public static readonly InvertVisibilityConverter InvertVisibility = new();
+    /// <summary>
+    /// The bg to readable.
+    /// </summary>
+    public static readonly BackgroundColorToBwForegroundConverter BgToReadable = new();
+    /// <summary>
+    /// The percentage.
+    /// </summary>
+    public static readonly PercentageConverter Percentage = new();
+    /// <summary>
+    /// The arithmetic.
+    /// </summary>
+    public static readonly ArithmeticConverter Arithmetic = new();
+    /// <summary>
+    /// The math.
+    /// </summary>
+    public static readonly MathConverter Math = new();
+    /// <summary>
+    /// The equality.
+    /// </summary>
+    public static readonly EqualityConverter Equality = new();
+    /// <summary>
+    /// The comparison.
+    /// </summary>
+    public static readonly ComparisonConverter Comparison = new();
+    /// <summary>
+    /// The and.
+    /// </summary>
+    public static readonly MultiBooleanAndConverter And = new();
+    /// <summary>
+    /// The or.
+    /// </summary>
+    public static readonly MultiBooleanOrConverter Or = new();
+    /// <summary>
+    /// The xor.
+    /// </summary>
+    public static readonly BooleanXorConverter Xor = new();
+    /// <summary>
+    /// The multi format.
+    /// </summary>
+    public static readonly MultiStringFormatConverter MultiFormat = new();
+}

--- a/src/XamlConverters/Generic/ComparisonConverter.cs
+++ b/src/XamlConverters/Generic/ComparisonConverter.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Compares the bound numeric (or IComparable) value against a parameter using the supplied operator.
+/// Parameter examples: ">5", ">= 10", "!=42", "&lt; -2", "==OFF" (string compare). Prefix with ! to invert result.
+/// </summary>
+public sealed class ComparisonConverter : IValueConverter
+{
+    private static readonly Regex _pattern = new("^(?<invert>!{0,1})(?<op>>=|<=|==|!=|>|<)\\s{0,}(?<rhs>.+)$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Executes the comparison.
+    /// </summary>
+    /// <param name="value">Left side value.</param>
+    /// <param name="targetType">Target type.</param>
+    /// <param name="parameter">Comparison expression.</param>
+    /// <param name="culture">Culture info.</param>
+    /// <returns>True if comparison holds.</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (parameter == null)
+        {
+            return false;
+        }
+
+        var paramText = parameter.ToString()!.Trim();
+        var m = _pattern.Match(paramText);
+        if (!m.Success)
+        {
+            return false; // invalid parameter
+        }
+
+        var invert = m.Groups["invert"].Value == "!";
+        var op = m.Groups["op"].Value;
+        var rhsText = m.Groups["rhs"].Value;
+
+        int comparison;
+        if (value is IComparable)
+        {
+            // Try to coerce numeric types.
+            if (double.TryParse(rhsText, NumberStyles.Any, culture, out var rhsDouble) && value is not string)
+            {
+                var lhsDouble = System.Convert.ToDouble(value, culture);
+                comparison = lhsDouble.CompareTo(rhsDouble);
+            }
+            else
+            {
+                comparison = string.Compare(value?.ToString(), rhsText, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+        else
+        {
+            return false;
+        }
+
+        var result = op switch
+        {
+            ">" => comparison > 0,
+            ">=" => comparison >= 0,
+            "<" => comparison < 0,
+            "<=" => comparison <= 0,
+            "==" => comparison == 0,
+            "!=" => comparison != 0,
+            _ => false,
+        };
+
+        return invert ? !result : result;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>Binding.DoNothing.</returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/Generic/EqualityConverter.cs
+++ b/src/XamlConverters/Generic/EqualityConverter.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Compares value to parameter using Equals. Optional parameter prefix '!' to invert result.
+/// </summary>
+public sealed class EqualityConverter : IValueConverter
+{
+    /// <summary>
+    /// Performs the equality comparison.
+    /// </summary>
+    /// <param name="value">Value from binding.</param>
+    /// <param name="targetType">Target type.</param>
+    /// <param name="parameter">Comparison parameter (optional '!' prefix).</param>
+    /// <param name="culture">Culture info.</param>
+    /// <returns>True if equal (with optional inversion).</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (parameter == null)
+        {
+            return value == null;
+        }
+
+        var parmStr = parameter.ToString();
+        var invert = false;
+        if (!string.IsNullOrEmpty(parmStr) && parmStr![0] == '!')
+        {
+            invert = true;
+            parmStr = parmStr.Substring(1);
+        }
+
+        var equals = value?.ToString()?.Equals(parmStr) == true;
+        return invert ? !equals : equals;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/Generic/ObjectEqualsParameterConverter.cs
+++ b/src/XamlConverters/Generic/ObjectEqualsParameterConverter.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Returns true if object's ToString() equals parameter (case-insensitive). Prefix parameter with ! to invert.
+/// </summary>
+public sealed class ObjectEqualsParameterConverter : IValueConverter
+{
+    /// <summary>
+    /// Compares the bound value string representation with the parameter.
+    /// </summary>
+    /// <param name="value">The bound value.</param>
+    /// <param name="targetType">The target type.</param>
+    /// <param name="parameter">Comparison string (optional leading ! to invert result).</param>
+    /// <param name="culture">The culture.</param>
+    /// <returns>True if equal (with optional inversion).</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (parameter == null)
+        {
+            return false;
+        }
+
+        var parm = parameter.ToString()!;
+        var invert = false;
+        if (parm.StartsWith("!", StringComparison.Ordinal))
+        {
+            invert = true;
+            parm = parm.Length > 1 ? parm.Substring(1) : string.Empty;
+        }
+
+        var equals = string.Equals(value?.ToString(), parm, StringComparison.OrdinalIgnoreCase);
+        return invert ? !equals : equals;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// Binding.DoNothing.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/Generic/ObjectToTypeNameConverter.cs
+++ b/src/XamlConverters/Generic/ObjectToTypeNameConverter.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Returns the simple type name of the bound object. If parameter is 'full', returns FullName.
+/// </summary>
+public sealed class ObjectToTypeNameConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value produced by the binding source.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value == null)
+        {
+            return string.Empty;
+        }
+
+        var full = parameter?.ToString()?.Equals("full", StringComparison.OrdinalIgnoreCase) == true;
+        var t = value.GetType();
+        return full ? t.FullName ?? t.Name : t.Name;
+    }
+
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/Layout/PercentageConverter.cs
+++ b/src/XamlConverters/Layout/PercentageConverter.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Multiplies a numeric value by the percentage supplied in the parameter. Parameter may be '50%' or '0.5'.
+/// </summary>
+public sealed class PercentageConverter : IValueConverter
+{
+    /// <summary>
+    /// Applies the percentage factor.
+    /// </summary>
+    /// <param name="value">The value produced by the binding source.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+        {
+            return 0d;
+        }
+
+        var baseVal = System.Convert.ToDouble(value, culture);
+        var parmText = parameter.ToString()!.Trim();
+        double factor;
+        if (parmText.EndsWith("%", StringComparison.Ordinal))
+        {
+            if (!double.TryParse(parmText.TrimEnd('%'), out var pct))
+            {
+                return baseVal;
+            }
+
+            factor = pct / 100d;
+        }
+        else
+        {
+            factor = double.TryParse(parmText, out var raw) ? raw : 1d;
+        }
+
+        return baseVal * factor;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/Layout/ThicknessUniformConverter.cs
+++ b/src/XamlConverters/Layout/ThicknessUniformConverter.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Creates a uniform (or partially uniform) Thickness from a numeric value. Parameter tokens: L,R,T,B,H,V to enable specific sides.
+/// Examples: parameter="LRT" sets Left/Right/Top only. Empty or null parameter sets all sides.
+/// </summary>
+public sealed class ThicknessUniformConverter : IValueConverter
+{
+    /// <summary>
+    /// Creates thickness from a numeric value and parameter tokens.
+    /// </summary>
+    /// <param name="value">Numeric value.</param>
+    /// <param name="targetType">Target type.</param>
+    /// <param name="parameter">Tokens controlling sides.</param>
+    /// <param name="culture">Culture info.</param>
+    /// <returns>A <see cref="Thickness"/> where only the specified sides are set to the provided value.</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var d = System.Convert.ToDouble(value, culture);
+        if (parameter == null)
+        {
+            return new Thickness(d);
+        }
+
+        var parm = parameter.ToString()!.ToUpperInvariant();
+        var t = default(Thickness); // avoid StyleCop warning SA1129
+        if (parm.Length == 0)
+        {
+            return new Thickness(d);
+        }
+
+        if (parm.Contains('L'))
+        {
+            t.Left = d;
+        }
+
+        if (parm.Contains('R'))
+        {
+            t.Right = d;
+        }
+
+        if (parm.Contains('T'))
+        {
+            t.Top = d;
+        }
+
+        if (parm.Contains('B'))
+        {
+            t.Bottom = d;
+        }
+
+        if (parm.Contains('H'))
+        {
+            t.Left = d;
+            t.Right = d;
+        }
+
+        if (parm.Contains('V'))
+        {
+            t.Top = d;
+            t.Bottom = d;
+        }
+
+        return t;
+    }
+
+    /// <summary>
+    /// Convert back is not supported for this converter.
+    /// </summary>
+    /// <param name="value">The value produced by the binding target (unused).</param>
+    /// <param name="targetType">The type to convert to (unused).</param>
+    /// <param name="parameter">The converter parameter to use (unused).</param>
+    /// <param name="culture">The culture to use in the converter (unused).</param>
+    /// <returns><see cref="Binding.DoNothing"/>.</returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/NullCoalesceConverter.cs
+++ b/src/XamlConverters/NullCoalesceConverter.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Returns the bound value unless it is null/empty (string) in which case returns the parameter.
+/// </summary>
+public sealed class NullCoalesceConverter : IValueConverter
+{
+    /// <summary>
+    /// Provides fallback for null or empty values.
+    /// </summary>
+    /// <param name="value">The bound value.</param>
+    /// <param name="targetType">Target type.</param>
+    /// <param name="parameter">Fallback value.</param>
+    /// <param name="culture">Culture info.</param>
+    /// <returns>Original or fallback value.</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is string s)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return parameter ?? string.Empty;
+            }
+
+            return s;
+        }
+
+        return value ?? parameter ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">Ignored.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// Binding.DoNothing.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/XamlConverters/Text/MultiStringFormatConverter.cs
+++ b/src/XamlConverters/Text/MultiStringFormatConverter.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Multi binding string formatter: parameter supplies a composite format string e.g. "{0} - {1:0.00} ({2})".
+/// Unset values are treated as empty strings.
+/// </summary>
+public sealed class MultiStringFormatConverter : IMultiValueConverter
+{
+    /// <summary>
+    /// Converts source values to a value for the binding target. The data binding engine calls this method when it propagates the values from source bindings to the binding target.
+    /// </summary>
+    /// <param name="values">The array of values that the source bindings in the <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to provide for conversion.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value.If the method returns null, the valid null value is used.A return value of <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the converter did not produce a value, and that the binding will use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default value.A return value of <see cref="T:System.Windows.Data.Binding" />.<see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
+    /// </returns>
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        var format = parameter as string;
+        if (string.IsNullOrEmpty(format))
+        {
+            return string.Join(" ", values.Where(v => v != DependencyProperty.UnsetValue && v != null));
+        }
+
+        var safeValues = values.Select(v => v == DependencyProperty.UnsetValue ? null : v).ToArray();
+        try
+        {
+            return string.Format(culture, format, safeValues);
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Converts a binding target value to the source binding values.
+    /// </summary>
+    /// <param name="value">The value that the binding target produces.</param>
+    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of values that are suggested for the method to return.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// An array of values that have been converted from the target value back to the source values.
+    /// </returns>
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => targetTypes.Select(_ => Binding.DoNothing).ToArray();
+}

--- a/src/XamlConverters/Visibility/BoolToVisibilityAdvancedConverter.cs
+++ b/src/XamlConverters/Visibility/BoolToVisibilityAdvancedConverter.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Advanced Bool->Visibility converter. Parameter tokens: ! to invert, H to use Hidden for false, C to force Collapsed.
+/// Examples: "!H" invert and Hidden; "!" invert with Collapsed; "H" true=Visible false=Hidden.
+/// </summary>
+public sealed class BoolToVisibilityAdvancedConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value produced by the binding source.</param>
+    /// <param name="targetType">The type of the binding target property.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var b = value is bool x && x;
+        var parm = parameter?.ToString() ?? string.Empty;
+        var invert = parm.Contains('!');
+        var useHidden = parm.Contains('H');
+        if (invert)
+        {
+            b = !b;
+        }
+
+        if (b)
+        {
+            return Visibility.Visible;
+        }
+
+        return useHidden ? Visibility.Hidden : Visibility.Collapsed;
+    }
+
+    /// <summary>
+    /// Converts a value.
+    /// </summary>
+    /// <param name="value">The value that is produced by the binding target.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// A converted value. If the method returns null, the valid null value is used.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is Visibility v)
+        {
+            var parm = parameter?.ToString() ?? string.Empty;
+            var invert = parm.Contains('!');
+            var isVisible = v == Visibility.Visible;
+            return invert ? !isVisible : isVisible;
+        }
+
+        return false;
+    }
+}

--- a/src/XamlConverters/Visibility/StringNullOrEmptyToVisibilityConverter.cs
+++ b/src/XamlConverters/Visibility/StringNullOrEmptyToVisibilityConverter.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CP.Xaml.Converters;
+
+/// <summary>
+/// Converts a string to Visibility.Collapsed when null or empty, else Visible.
+/// Optional parameter: "invert" to invert logic, "hidden" to use Hidden instead of Collapsed.
+/// </summary>
+public sealed class StringNullOrEmptyToVisibilityConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts the bound string to a Visibility.
+    /// </summary>
+    /// <param name="value">The bound value.</param>
+    /// <param name="targetType">Target type.</param>
+    /// <param name="parameter">Parameter tokens (invert, hidden, hiddeninvert).</param>
+    /// <param name="culture">Culture info.</param>
+    /// <returns>Visibility based on rules.</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var str = value as string;
+        var isNullOrEmpty = string.IsNullOrEmpty(str);
+        var parm = parameter?.ToString()?.ToLowerInvariant();
+        var invert = parm == "invert" || parm == "true";
+        var useHidden = parm == "hidden" || parm == "hiddeninvert";
+
+        if (parm == "hiddeninvert")
+        {
+            invert = true;
+            useHidden = true;
+        }
+
+        var show = invert ? isNullOrEmpty : !isNullOrEmpty;
+        if (show)
+        {
+            return Visibility.Visible;
+        }
+
+        return useHidden ? Visibility.Hidden : Visibility.Collapsed;
+    }
+
+    /// <summary>
+    /// Convert back not supported.
+    /// </summary>
+    /// <param name="value">Ignored.</param>
+    /// <param name="targetType">The type to convert to.</param>
+    /// <param name="parameter">The converter parameter to use.</param>
+    /// <param name="culture">The culture to use in the converter.</param>
+    /// <returns>
+    /// Binding.DoNothing.
+    /// </returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}


### PR DESCRIPTION
Introduces a suite of reusable value converters for XAML, including boolean, collection, comparison, arithmetic, and formatting converters. Adds a static registry for easy access to singleton converter instances. Includes a new test project with extensive xUnit test coverage for all converters. Updates project files for .NET 8/9 and removes global.json.