### PR TITLE
Update dependencies, docs, and test targets for .NET 9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,6 @@
     <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>preview</LangVersion>
-    <Configuration>$(TargetFramework)</Configuration>
     <Company>ChrisPulman</Company>
     <NoWarn>CS1591;IDE0190;IDE1006</NoWarn>
     <Nullable>enable</Nullable>
@@ -54,9 +53,9 @@
 
   <ItemGroup>
     <!--<Compile Update="**\*.cs" DependentUpon="I%(Filename).cs" />-->
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="all" />
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.14.0" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,72 +1,248 @@
-# XamlConverters
-Converters for WPF
+﻿# XamlConverters
+Converters for WPF (.NET Framework 4.6.2 / .NET 8 / .NET 9)
 
 ![Nuget](https://img.shields.io/nuget/v/CP.Xaml.Converters) ![Nuget](https://img.shields.io/nuget/dt/CP.Xaml.Converters)
 
-Converters available are:
+A rich collection of ready-to-use value & multi-value converters for WPF plus some numeric markup extensions.
 
--  ArithmeticConverter
--  BackgroundColorToBwForegroundConverter
--  BoolNegationConverter
--  BoolToOpacityConverter
--  BoolToStringTickCrossConverter
--  BoolToVisibilityConverter
--  BoolToVisibilityConverterNegate
--  CollectionSizeToBoolConverter
--  CollectionSizeToVisibilityConverter
--  ColorToBrushConverter
--  DoubleToCurrencyStringConverter
--  EnumConverter
--  HexStringToColorConverter
--  HexStringToSolidColorBrushConverter
--  IntToThicknessConverter
--  IntToVisibilityConverter
--  InverseValueToBoolConverter
--  InvertSignConverter
--  InvertValueConverter
--  InvertVisibilityConverter
--  IsGreaterThanOrEqualToConverter
--  LineStrokeLevelConverter
--  ToLowerConverter
--  MathConverter
--  MultiConverter
--  MultiplierConverter
--  NullToBoolConverter
--  NullToVisibilityConverter
--  ToUpperConverter
--  ValueCompareVisibilityConverter
--  ValueGreaterThanXToBoolConverter
--  ValueGtXConverter
--  ValueLessThanXToBoolConverter
--  ValueNotNullToBoolConverter
--  ValueNotNullToVisibilityConverter
--  ValueToBrushConverter
--  VisibilityFromNumberConverter
--  VisibilityFromNumberEqualsConverter
--  ZeroToVisibilityConverter
- - BrushToColorConverter
- - FallbackBrushConverter
-
-## Usage
-
-
-Add the namespace to your App.xaml file:
-
-```xaml
-xmlns:converters="https://github.com/ChrisPulman/XamlConverters"
+---
+## Install
+```
+PM> Install-Package CP.Xaml.Converters
 ```
 
-Then add the ConvertersDictionary to your resources in App.xaml:
-
+---
+## Quick Start (All Converters at Once)
 ```xaml
-<Application.Resources>
-    <converters:ConvertersDictionary />
-</Application.Resources>
+<Application x:Class="App" ...
+             xmlns:converters="https://github.com/ChrisPulman/XamlConverters">
+    <Application.Resources>
+        <converters:ConvertersDictionary />
+    </Application.Resources>
+</Application>
+```
+Use in bindings:
+```xaml
+<TextBlock Text="{Binding Title, Converter={StaticResource ToUpperConverter}}"/>
 ```
 
-This will make all of the converters available to your application.
-Then use it by selecting a `Converter={StaticResource #CONVERTER#}}` such as:
-
+---
+## Lightweight Usage (Singletons)
+Some frequently used stateless converters are exposed through `ConvertersRegistry` so you can avoid resource keys:
 ```xaml
-<TextBlock Text="{Binding MyProperty, Converter={StaticResource ToUpperConverter}}" />
+xmlns:c="clr-namespace:CP.Xaml.Converters"
+<TextBlock Visibility="{Binding IsBusy, Converter={x:Static c:ConvertersRegistry.BoolToVisibility}}"/>
 ```
+Available singletons (see ConvertersRegistry.cs): Not, BoolToVisibility, BoolToVisibilityAdv, NotNullToVisibility, NotNullToBool, NullToBool, NullCoalesce, InvertVisibility, BgToReadable, Percentage, Arithmetic, Math, Equality, Comparison, And, Or, Xor, MultiFormat.
+
+---
+## Markup Numeric Extensions
+Allow inline numeric objects in XAML without x:Static:
+```xaml
+xmlns:c="clr-namespace:CP.Xaml.Converters"
+<Setter Property="Tag" Value="{c:Int32 42}"/>
+<Setter Property="Tag" Value="{c:Double 2.5}"/>
+```
+Available: Int16, Int32, Single (float), Double.
+
+---
+## Converter Catalogue
+(Each listed as Resource Key = Class Name when using ConvertersDictionary)
+
+### Arithmetic & Math
+- ArithmeticConverter – Parameter: simple expression "<op><number>" e.g. "+5", "-2", "*3", "/10". Works with int/double.
+  ```xaml
+  <TextBlock Text="{Binding Count, Converter={StaticResource ArithmeticConverter}, ConverterParameter='*2'}"/>
+  ```
+- MathConverter – Parameter: arithmetic expression over one or many bound values. Single binding uses value as {0}/x; MultiBinding supports {0},{1}… or a,b,c,d.
+  ```xaml
+  <!-- Scale * Percentage example -->
+  <TextBlock>
+    <TextBlock.Text>
+      <MultiBinding Converter="{StaticResource MathConverter}" ConverterParameter="({0} * {1}) / 100">
+        <Binding Path="Base"/>
+        <Binding Path="Percent"/>
+      </MultiBinding>
+    </TextBlock.Text>
+  </TextBlock>
+  ```
+- PercentageConverter – Parameter: either "50%" or decimal factor "0.5" multiplies numeric value.
+  ```xaml
+  <RowDefinition Height="{Binding ActualWidth, ElementName=Root, Converter={StaticResource PercentageConverter}, ConverterParameter=25%}" />
+  ```
+- MultiplierConverter – Parameter: numeric factor; ConvertBack divides.
+  ```xaml
+  <Rectangle Width="{Binding BaseWidth, Converter={StaticResource MultiplierConverter}, ConverterParameter=1.5}"/>
+  ```
+- ValueGtXConverter – Rounds `double` to 1 decimal place if > parameter else 2.
+  ```xaml
+  <TextBlock Text="{Binding Speed, Converter={StaticResource ValueGtXConverter}, ConverterParameter=40}"/>
+  ```
+- ValueGreaterThanXToBoolConverter / ValueLessThanXToBoolConverter – Parameter: threshold (default 0). Returns bool. ConvertBack adjusts relative to threshold.
+  ```xaml
+  <CheckBox IsChecked="{Binding ItemsCount, Converter={StaticResource ValueGreaterThanXToBoolConverter}, ConverterParameter=5}" Content=">5?"/>
+  ```
+- IsGreaterThanOrEqualToConverter – (a) Single binding + parameter (b) MultiBinding with two inputs.
+  ```xaml
+  <CheckBox IsChecked="{Binding Value, Converter={StaticResource IsGreaterThanOrEqualToConverter}, ConverterParameter=100}"/>
+  ```
+
+### Boolean Logic / Aggregation
+- BoolNegationConverter – Inverts bool.
+- MultiBooleanAndConverter – MultiBinding; optional parameter "invert".
+- MultiBooleanOrConverter – MultiBinding; optional parameter "invert".
+- BooleanXorConverter – MultiBinding exclusive OR (true if odd number true).
+- InverseValueToBoolConverter – True if numeric <= 0.
+- NullToBoolConverter – Use `NullToBoolConverter.IsNull` or `.NotNull` static singletons; or set `ReturnTrueIfNull` property in XAML.
+- ValueNotNullToBoolConverter – Parameter: "reverse" or "true" to invert.
+- ObjectEqualsParameterConverter – Parameter: string to compare; prefix ! to invert.
+- EqualityConverter – Parameter: value to compare; prefix ! to invert.
+- ComparisonConverter – Parameter: comparison expression e.g. ">5", "<= 10", "!=X", "!>=3" (leading ! inverts result). Works with numeric or string.
+- EnumToBooleanConverter – Parameter: enum member name; useful for RadioButtons.
+  ```xaml
+  <RadioButton Content="Large" IsChecked="{Binding Size, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Large}"/>
+  ```
+
+### Visibility
+- BoolToVisibilityConverter – Parameter: "reverse" or "true" to invert.
+- BoolToVisibilityAdvancedConverter – Parameter tokens: ! (invert), H (Hidden instead of Collapsed). Examples: "!H", "H".
+- BoolToVisibilityConverterNegate – Opposite of normal: true => Collapsed/Hidden, false => Visible. Parameter: "hidden" to use Hidden.
+- InvertVisibilityConverter – Toggles Visible <-> Collapsed (parameter containing "hidden" toggles Visible <-> Hidden).
+- IntToVisibilityConverter – Shows when int > 0. Parameter: "hidden" to hide instead of collapse.
+- ValueNotNullToVisibilityConverter – Parameter: "reverse" or "true" to invert.
+- NullToVisibilityConverter – Shows when null; parameter "inverse" reverses.
+- StringNullOrEmptyToVisibilityConverter – Collapses when null/empty. Parameter: "invert", "hidden", or "hiddeninvert".
+- CollectionSizeToVisibilityConverter – Parameter: either integer exact size OR "reverse" (see CollectionSizeToBoolConverter). Shows when size matches.
+- CountToVisibilityConverter – Parameter: comparison expression like ">0", "==0", may append H to use Hidden (e.g. ">0H").
+- ValueCompareVisibilityConverter – Shows when numeric > 0 (Hidden when <=0).
+- VisibilityFromNumberConverter – Parameter: integer threshold; Visible when value >= threshold.
+- VisibilityFromNumberEqualsConverter – Visible when value == parameter.
+- ZeroToVisibilityConverter – Visible when value == 0.
+
+### Collection Size / Count
+- CollectionSizeToBoolConverter – Parameter: integer required size OR "reverse". True when count equals size (default 0).
+- CountToBooleanConverter – Parameter: comparison (>,>=,<,<=,==,!=) e.g. ">0" (default >0 if omitted).
+  ```xaml
+  <CheckBox IsChecked="{Binding Items, Converter={StaticResource CountToBooleanConverter}, ConverterParameter='>5'}" Content=">5 Items"/>
+  ```
+
+### Text & Formatting
+- ToUpperConverter / ToLowerConverter – Case conversion.
+- MultiStringFormatConverter – MultiBinding; parameter is composite format string: "{0} - {1:0.00} ({2})".
+  ```xaml
+  <TextBlock>
+    <TextBlock.Text>
+      <MultiBinding Converter="{StaticResource MultiStringFormatConverter}" ConverterParameter="{0} - {1:0.0} ({2})">
+        <Binding Path="Name"/>
+        <Binding Path="Price"/>
+        <Binding Path="Code"/>
+      </MultiBinding>
+    </TextBlock.Text>
+  </TextBlock>
+  ```
+- NullCoalesceConverter – If bound value is null/empty string returns ConverterParameter (fallback).
+  ```xaml
+  <TextBlock Text="{Binding Description, Converter={StaticResource NullCoalesceConverter}, ConverterParameter='(none)'}"/>
+  ```
+- BoolToStringTickCrossConverter – true => "P", false => "O" (style with a symbol font if desired).
+
+### Colors / Brushes
+- BackgroundColorToBwForegroundConverter – Input background hex (#RRGGBB) -> White or Black foreground for readability.
+- HexStringToColorConverter – Accepts `#RRGGBB` or `RRGGBB` returns Color.
+- HexStringToSolidColorBrushConverter – Same but returns SolidColorBrush.
+- ColorToBrushConverter – Hex/String Color -> SolidColorBrush.
+- BrushToColorConverter – Brush/Color -> Color (or Red fallback).
+- FallbackBrushConverter – Brush or Color; fallback is Red.
+- ValueToBrushConverter – Parameter optional tokens: contains "BackPressure" or "Pressure" to choose palette; default DarkGreen if value>0 else LightYellow.
+- ValueCompareVisibilityConverter (see Visibility) – also for numeric state color with Hidden.
+- LineStrokeLevelConverter – Parameter: "low-high" (e.g. "50-80"). Returns Lime (<low), Yellow (>=low), Red (>=high).
+- ValueGtXConverter – Rounds numeric (see above) – helpful for numeric UI formatting.
+
+### Numeric / Layout
+- IntToThicknessConverter – Optionally sets specific sides via instance variants (BottomOnly, LeftOnly, etc.) when using registry or custom resource. Parameter may be a base Thickness.
+  ```xaml
+  <Border Padding="{Binding Spacer, Converter={StaticResource IntToThicknessConverter}, ConverterParameter='4,2,4,2'}"/>
+  ```
+- ThicknessUniformConverter – Parameter tokens control sides: L,R,T,B or H (Left+Right), V (Top+Bottom). Empty => all sides.
+  ```xaml
+  <Border Padding="{Binding Gap, Converter={StaticResource ThicknessUniformConverter}, ConverterParameter=HV}"/>
+  ```
+- MultiplierConverter / PercentageConverter – see Arithmetic section.
+- InvertSignConverter / InvertValueConverter – Negate numeric; InvertSignConverter coerces to target type.
+- DoubleToCurrencyStringConverter – Formats double/decimal to currency using current culture.
+- ValueCompareVisibilityConverter – Numeric <=0 hidden else visible.
+- InverseValueToBoolConverter – Numeric <=0 => true.
+
+### Type / Object Info
+- ObjectToTypeNameConverter – Parameter: "full" for full type name.
+- ObjectEqualsParameterConverter / EqualityConverter / ComparisonConverter – See Boolean section.
+- EnumConverter – Parameter: Type (x:Type) to parse a string value to enum.
+  ```xaml
+  <ComboBox SelectedValue="{Binding SelectedStatus}" SelectedValuePath="Tag">
+    <ComboBoxItem Content="Open" Tag="{Binding 'Open', Converter={StaticResource EnumConverter}, ConverterParameter={x:Type local:TicketStatus}}"/>
+  </ComboBox>
+  ```
+
+### Chaining Converters
+Use MultiConverter to pipe the output of one into the next:
+```xaml
+<converters:MultiConverter x:Key="InvertVisibilityChain">
+  <converters:BoolNegationConverter/>
+  <converters:BoolToVisibilityConverter/>
+</converters:MultiConverter>
+<TextBlock Visibility="{Binding IsClosed, Converter={StaticResource InvertVisibilityChain}}"/>
+```
+
+### MultiBinding Boolean Examples
+```xaml
+<!-- Show only when all are true -->
+<TextBlock Text="Ready" Visibility="{Binding Path=., Converter={x:Static c:ConvertersRegistry.BoolToVisibility}}">
+  <TextBlock.Visibility>
+    <MultiBinding Converter="{x:Static c:ConvertersRegistry.And}">
+      <Binding Path="IsLoaded"/>
+      <Binding Path="IsValid"/>
+      <Binding Path="HasPermission"/>
+    </MultiBinding>
+  </TextBlock.Visibility>
+</TextBlock>
+```
+
+---
+## Error & Edge Notes
+- Many converters throw if value types mismatch (fail fast). Ensure proper binding types.
+- MathConverter caches parsed expressions internally.
+- Comparison expressions (ComparisonConverter / CountToBooleanConverter) ignore malformed parameters and return default semantics.
+- Some visibility converters support Hidden vs Collapsed selection via parameter tokens (H / hidden).
+
+---
+## Minimal Example Window
+```xaml
+<Window ... xmlns:conv="https://github.com/ChrisPulman/XamlConverters">
+  <Window.Resources>
+    <conv:ConvertersDictionary />
+  </Window.Resources>
+  <StackPanel Margin="20" DataContext="{Binding SampleViewModelInstance}">
+    <TextBlock Text="{Binding Title, Converter={StaticResource ToUpperConverter}}"/>
+    <TextBlock Text="{Binding Amount, Converter={StaticResource DoubleToCurrencyStringConverter}}"/>
+    <ProgressBar Value="{Binding Progress}" Maximum="100" Height="20"/>
+    <TextBlock Text="{Binding Progress, Converter={StaticResource ArithmeticConverter}, ConverterParameter='*2'}"/>
+    <TextBlock Foreground="{Binding HexColour, Converter={StaticResource BackgroundColorToBwForegroundConverter}}"
+               Background="{Binding HexColour, Converter={StaticResource HexStringToSolidColorBrushConverter}}"
+               Text="Contrast Demo" Padding="8"/>
+    <CheckBox Content="Is Active" IsChecked="{Binding IsActive}"/>
+    <TextBlock Text="Active" Visibility="{Binding IsActive, Converter={StaticResource BoolToVisibilityConverter}}"/>
+  </StackPanel>
+</Window>
+```
+
+---
+## Contributing
+PRs welcome. Please keep converters small, focused, documented and unit-tested.
+
+---
+## License
+MIT
+
+---
+
+**XamlConverters** - By Chris Pulman - Empowering Industrial Automation with Reactive Technology ⚡🏭

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -58,7 +58,7 @@ partial class Build : NukeBuild
             }
 
             PackagesDirectory.CreateOrCleanDirectory();
-            await this.InstallDotNetSdk("6.x.x", "7.x.x", "8.x.x");
+            await this.InstallDotNetSdk("8.x.x", "9.x.x");
         });
 
     Target Restore => _ => _

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageReference Include="Nuke.Common" Version="9.0.4" />
     <PackageReference Include="CP.Nuke.BuildTools" Version="1.0.79" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="nbgv" Version="[3.6.133]" />
+    <PackageDownload Include="nbgv" Version="[3.7.115]" />
   </ItemGroup>
 
 </Project>

--- a/src/XamlConverters.Tests/BoolToVisibilityAdvancedConverterTests.cs
+++ b/src/XamlConverters.Tests/BoolToVisibilityAdvancedConverterTests.cs
@@ -3,8 +3,14 @@
 
 namespace CP.Xaml.Converters.Tests;
 
+/// <summary>
+/// BoolToVisibilityAdvancedConverterTests.
+/// </summary>
 public class BoolToVisibilityAdvancedConverterTests
 {
+    /// <summary>
+    /// Trues the visible.
+    /// </summary>
     [Fact]
     public void TrueVisible()
     {
@@ -13,6 +19,9 @@ public class BoolToVisibilityAdvancedConverterTests
         Assert.Equal(Visibility.Visible, result);
     }
 
+    /// <summary>
+    /// Falses the collapsed.
+    /// </summary>
     [Fact]
     public void FalseCollapsed()
     {
@@ -21,6 +30,9 @@ public class BoolToVisibilityAdvancedConverterTests
         Assert.Equal(Visibility.Collapsed, result);
     }
 
+    /// <summary>
+    /// Falses the hidden when h.
+    /// </summary>
     [Fact]
     public void FalseHiddenWhenH()
     {

--- a/src/XamlConverters.Tests/BoolToVisibilityConverterTests.cs
+++ b/src/XamlConverters.Tests/BoolToVisibilityConverterTests.cs
@@ -3,8 +3,16 @@
 
 namespace CP.Xaml.Converters.Tests;
 
+/// <summary>
+/// BoolToVisibilityConverterTests.
+/// </summary>
 public class BoolToVisibilityConverterTests
 {
+    /// <summary>
+    /// Convertses the bool to visibility.
+    /// </summary>
+    /// <param name="input">if set to <c>true</c> [input].</param>
+    /// <param name="expected">The expected.</param>
     [Theory]
     [InlineData(true, Visibility.Visible)]
     [InlineData(false, Visibility.Collapsed)]
@@ -15,6 +23,11 @@ public class BoolToVisibilityConverterTests
         Assert.Equal(expected, result);
     }
 
+    /// <summary>
+    /// Convertses the bool to visibility inverted.
+    /// </summary>
+    /// <param name="input">if set to <c>true</c> [input].</param>
+    /// <param name="expected">The expected.</param>
     [Theory]
     [InlineData(true, Visibility.Collapsed)]
     [InlineData(false, Visibility.Visible)]

--- a/src/XamlConverters.Tests/CP.Xaml.Converters.Tests.csproj
+++ b/src/XamlConverters.Tests/CP.Xaml.Converters.Tests.csproj
@@ -1,18 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0-windows;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows;net9.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Suppress style/documentation rules for tests -->
-    <NoWarn>SA1600;SA1402;SA1502;SA1136;SA1602;SA1512;SA1513</NoWarn>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\XamlConverters\CP.Xaml.Converters.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" PrivateAssets="all" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/XamlConverters.Tests/ComparisonConverterTests.cs
+++ b/src/XamlConverters.Tests/ComparisonConverterTests.cs
@@ -3,8 +3,17 @@
 
 namespace CP.Xaml.Converters.Tests;
 
+/// <summary>
+/// ComparisonConverterTests.
+/// </summary>
 public class ComparisonConverterTests
 {
+    /// <summary>
+    /// Compareses the values.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <param name="param">The parameter.</param>
+    /// <param name="expected">if set to <c>true</c> [expected].</param>
     [Theory]
     [InlineData(5, ">3", true)]
     [InlineData(3, ">3", false)]

--- a/src/XamlConverters.Tests/CountConvertersTests.cs
+++ b/src/XamlConverters.Tests/CountConvertersTests.cs
@@ -3,8 +3,14 @@
 
 namespace CP.Xaml.Converters.Tests;
 
+/// <summary>
+/// CountConvertersTests.
+/// </summary>
 public class CountConvertersTests
 {
+    /// <summary>
+    /// Counts to boolean greater than zero.
+    /// </summary>
     [Fact]
     public void CountToBoolean_GreaterThanZero()
     {
@@ -13,6 +19,9 @@ public class CountConvertersTests
         Assert.True((bool)result);
     }
 
+    /// <summary>
+    /// Counts to visibility equals zero collapsed.
+    /// </summary>
     [Fact]
     public void CountToVisibility_EqualsZeroCollapsed()
     {

--- a/src/XamlConverters.Tests/EnumToBooleanConverterTests.cs
+++ b/src/XamlConverters.Tests/EnumToBooleanConverterTests.cs
@@ -3,10 +3,17 @@
 
 namespace CP.Xaml.Converters.Tests;
 
-public enum TestState { One, Two }
-
+/// <summary>
+/// EnumToBooleanConverterTests.
+/// </summary>
 public class EnumToBooleanConverterTests
 {
+    /// <summary>
+    /// Enums the matches.
+    /// </summary>
+    /// <param name="state">The state.</param>
+    /// <param name="param">The parameter.</param>
+    /// <param name="expected">if set to <c>true</c> [expected].</param>
     [Theory]
     [InlineData(TestState.One, "One", true)]
     [InlineData(TestState.One, "Two", false)]

--- a/src/XamlConverters.Tests/NullCoalesceConverterTests.cs
+++ b/src/XamlConverters.Tests/NullCoalesceConverterTests.cs
@@ -3,8 +3,14 @@
 
 namespace CP.Xaml.Converters.Tests;
 
+/// <summary>
+/// NullCoalesceConverterTests.
+/// </summary>
 public class NullCoalesceConverterTests
 {
+    /// <summary>
+    /// Returnses the parameter if null.
+    /// </summary>
     [Fact]
     public void ReturnsParameterIfNull()
     {
@@ -13,6 +19,9 @@ public class NullCoalesceConverterTests
         Assert.Equal("fallback", result);
     }
 
+    /// <summary>
+    /// Returnses the value if not null.
+    /// </summary>
     [Fact]
     public void ReturnsValueIfNotNull()
     {

--- a/src/XamlConverters.Tests/PercentageConverterTests.cs
+++ b/src/XamlConverters.Tests/PercentageConverterTests.cs
@@ -3,8 +3,17 @@
 
 namespace CP.Xaml.Converters.Tests;
 
+/// <summary>
+/// PercentageConverterTests.
+/// </summary>
 public class PercentageConverterTests
 {
+    /// <summary>
+    /// Applieses the percentage.
+    /// </summary>
+    /// <param name="input">The input.</param>
+    /// <param name="param">The parameter.</param>
+    /// <param name="expected">The expected.</param>
     [Theory]
     [InlineData(200, "50%", 100)]
     [InlineData(10, "0.5", 5)]

--- a/src/XamlConverters.Tests/TestState.cs
+++ b/src/XamlConverters.Tests/TestState.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CP.Xaml.Converters.Tests;
+
+/// <summary>
+/// TestState.
+/// </summary>
+public enum TestState
+{
+    /// <summary>
+    /// The one.
+    /// </summary>
+    One,
+    /// <summary>
+    /// The two.
+    /// </summary>
+    Two
+}

--- a/src/XamlConverters.Tests/ThicknessUniformConverterTests.cs
+++ b/src/XamlConverters.Tests/ThicknessUniformConverterTests.cs
@@ -3,8 +3,14 @@
 
 namespace CP.Xaml.Converters.Tests;
 
+/// <summary>
+/// ThicknessUniformConverterTests.
+/// </summary>
 public class ThicknessUniformConverterTests
 {
+    /// <summary>
+    /// Alls the sides.
+    /// </summary>
     [Fact]
     public void AllSides()
     {
@@ -13,6 +19,9 @@ public class ThicknessUniformConverterTests
         Assert.Equal(new Thickness(5), t);
     }
 
+    /// <summary>
+    /// Horizontals the only.
+    /// </summary>
     [Fact]
     public void HorizontalOnly()
     {

--- a/src/XamlConverters/CP.Xaml.Converters.csproj
+++ b/src/XamlConverters/CP.Xaml.Converters.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0-windows;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows;net9.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.2",
+    "version": "1.1",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"


### PR DESCRIPTION
Upgraded Nerdbank.GitVersioning and Roslynator.Analyzers, updated build scripts and test projects to target .NET 9 and .NET 4.7.2, and improved test project dependencies. Expanded and clarified the README with detailed usage, converter catalogue, and examples. Added missing TestState enum for tests and enhanced test code documentation with XML comments. Bumped version to 1.1.