### PR TITLE
chore(deps): update packages and resolve analyzer diagnostics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,9 +8,9 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
-    <PackageVersion Include="NuGet.Packaging" Version="6.12.5" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.14.3" />
     <PackageVersion Include="Polyfill" Version="10.11.2" />
-    <PackageVersion Include="StyleSharp.Analyzers" Version="3.20.0" />
+    <PackageVersion Include="StyleSharp.Analyzers" Version="3.21.10" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="TUnit" Version="1.59.0" />

--- a/src/XamlConverters.Avalonia.Tests/CommonConverterTests.cs
+++ b/src/XamlConverters.Avalonia.Tests/CommonConverterTests.cs
@@ -38,8 +38,13 @@ public class CommonConverterTests
 
         var guidText = guidConverter.Convert(guid, typeof(string), "N", InvariantCulture);
         var parsedGuid = guidConverter.ConvertBack(guidText, typeof(Guid), null, InvariantCulture);
-        var encoded = base64Converter.Convert(new byte[] { 1, TestValues.SecondByte, TestValues.ThirdByte }, typeof(string), null, InvariantCulture);
-        var decoded = (byte[])base64Converter.ConvertBack(encoded, typeof(byte[]), null, InvariantCulture);
+        var encoded = base64Converter.Convert(
+            new byte[] { 1, TestValues.SecondByte, TestValues.ThirdByte },
+            typeof(string),
+            null,
+            InvariantCulture);
+        var decoded = (byte[])
+            base64Converter.ConvertBack(encoded, typeof(byte[]), null, InvariantCulture);
 
         await Assert.That(guidText).IsEqualTo("a75dd9c5b47d4bf7b547946da756f6d7");
         await Assert.That(parsedGuid).IsEqualTo(guid);
@@ -53,11 +58,32 @@ public class CommonConverterTests
     [Test]
     public async Task ConvertsCollectionValues()
     {
-        var values = new[] { TestValues.FirstSampleValue, TestValues.SecondSampleValue, TestValues.ThirdSampleValue };
-        var contains = new CollectionContainsConverter().Convert(values, typeof(bool), "20", InvariantCulture);
-        var item = new CollectionItemConverter().Convert(values, typeof(int), "1", InvariantCulture);
-        var first = new CollectionFirstOrDefaultConverter().Convert(Array.Empty<int>(), typeof(int), TestValues.MissingSampleValue, InvariantCulture);
-        var joined = new EnumerableToStringConverter().Convert(values, typeof(string), "|", InvariantCulture);
+        var values = new[]
+        {
+            TestValues.FirstSampleValue,
+            TestValues.SecondSampleValue,
+            TestValues.ThirdSampleValue,
+        };
+        var contains = new CollectionContainsConverter().Convert(
+            values,
+            typeof(bool),
+            "20",
+            InvariantCulture);
+        var item = new CollectionItemConverter().Convert(
+            values,
+            typeof(int),
+            "1",
+            InvariantCulture);
+        var first = new CollectionFirstOrDefaultConverter().Convert(
+            Array.Empty<int>(),
+            typeof(int),
+            TestValues.MissingSampleValue,
+            InvariantCulture);
+        var joined = new EnumerableToStringConverter().Convert(
+            values,
+            typeof(string),
+            "|",
+            InvariantCulture);
 
         await Assert.That((bool)contains).IsTrue();
         await Assert.That(item).IsEqualTo(TestValues.SecondSampleValue);
@@ -75,9 +101,18 @@ public class CommonConverterTests
         var values = new EnumValuesConverter();
 
         var text = description.Convert(SampleFlags.Read, typeof(string), null, InvariantCulture);
-        var enumValue = description.ConvertBack("Can read", typeof(SampleFlags), null, InvariantCulture);
-        var hasFlag = flag.Convert(SampleFlags.Read | SampleFlags.Write, typeof(bool), "Write", InvariantCulture);
-        var enumValues = (Array)values.Convert(typeof(SampleFlags), typeof(IEnumerable), null, InvariantCulture);
+        var enumValue = description.ConvertBack(
+            "Can read",
+            typeof(SampleFlags),
+            null,
+            InvariantCulture);
+        var hasFlag = flag.Convert(
+            SampleFlags.Read | SampleFlags.Write,
+            typeof(bool),
+            "Write",
+            InvariantCulture);
+        var enumValues = (Array)
+            values.Convert(typeof(SampleFlags), typeof(IEnumerable), null, InvariantCulture);
 
         await Assert.That(text).IsEqualTo("Can read");
         await Assert.That(enumValue).IsEqualTo(SampleFlags.Read);

--- a/src/XamlConverters.Avalonia/ArithmeticConverter.cs
+++ b/src/XamlConverters.Avalonia/ArithmeticConverter.cs
@@ -30,7 +30,13 @@ public sealed partial class ArithmeticConverter : IValueConverter
         }
 
         var match = Expression.Match(parameter?.ToString() ?? string.Empty);
-        if (!match.Success || !decimal.TryParse(match.Groups[NumberGroupName].Value, NumberStyles.Any, culture, out var right))
+        if (
+            !match.Success
+            || !decimal.TryParse(
+                match.Groups[NumberGroupName].Value,
+                NumberStyles.Any,
+                culture,
+                out var right))
         {
             return ConversionHelpers.UnsetValue;
         }
@@ -43,12 +49,24 @@ public sealed partial class ArithmeticConverter : IValueConverter
             "/" when right != 0 => left / right,
             _ => (decimal?)null,
         };
-        return result is { } number ? ConversionHelpers.ConvertDecimal(number, targetType, culture) : ConversionHelpers.UnsetValue;
+        return result is { } number
+            ? ConversionHelpers.ConvertDecimal(number, targetType, culture)
+            : ConversionHelpers.UnsetValue;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
-    [GeneratedRegex("^\\s*(?<" + OperatorGroupName + ">[+\\-*/])\\s*(?<" + NumberGroupName + ">[+\\-]?(?:\\d+(?:[.,]\\d*)?|[.,]\\d+))\\s*$", RegexOptions.Compiled)]
+    [GeneratedRegex(
+        "^\\s*(?<"
+            + OperatorGroupName
+            + ">[+\\-*/])\\s*(?<"
+            + NumberGroupName
+            + ">[+\\-]?(?:\\d+(?:[.,]\\d*)?|[.,]\\d+))\\s*$",
+        RegexOptions.Compiled)]
     private static partial Regex MyRegex();
 }

--- a/src/XamlConverters.Avalonia/BackgroundColorToBwForegroundConverter.cs
+++ b/src/XamlConverters.Avalonia/BackgroundColorToBwForegroundConverter.cs
@@ -13,19 +13,19 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class BackgroundColorToBwForegroundConverter : IValueConverter
 {
     /// <summary>The red-channel luminance coefficient.</summary>
-    private const double RedLuminanceWeight = 0.2126d;
+    private const double RedLuminanceWeight = 0.2126D;
 
     /// <summary>The green-channel luminance coefficient.</summary>
-    private const double GreenLuminanceWeight = 0.7152d;
+    private const double GreenLuminanceWeight = 0.7152D;
 
     /// <summary>The blue-channel luminance coefficient.</summary>
-    private const double BlueLuminanceWeight = 0.0722d;
+    private const double BlueLuminanceWeight = 0.0722D;
 
     /// <summary>The maximum value of a color channel.</summary>
-    private const double MaximumChannelValue = 255d;
+    private const double MaximumChannelValue = 255D;
 
     /// <summary>The normalized luminance threshold between white and black foregrounds.</summary>
-    private const double ContrastThreshold = 0.5d;
+    private const double ContrastThreshold = 0.5D;
 
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -35,10 +35,18 @@ public sealed class BackgroundColorToBwForegroundConverter : IValueConverter
             return Brushes.Black;
         }
 
-        var luminance = ((RedLuminanceWeight * color.R) + (GreenLuminanceWeight * color.G) + (BlueLuminanceWeight * color.B)) / MaximumChannelValue;
+        var luminance =
+            (
+                (RedLuminanceWeight * color.R)
+                + (GreenLuminanceWeight * color.G)
+                + (BlueLuminanceWeight * color.B)) / MaximumChannelValue;
         return luminance <= ContrastThreshold ? Brushes.White : Brushes.Black;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/BclTypeConverter.cs
+++ b/src/XamlConverters.Avalonia/BclTypeConverter.cs
@@ -12,10 +12,22 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class BclTypeConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryConvert(value, targetType, culture, out var result) ? result : ConversionHelpers.UnsetValue;
+    public object? Convert(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
+        ConversionHelpers.TryConvert(value, targetType, culture, out var result)
+            ? result
+            : ConversionHelpers.UnsetValue;
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryConvert(value, targetType, culture, out var result) ? result : ConversionHelpers.UnsetValue;
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
+        ConversionHelpers.TryConvert(value, targetType, culture, out var result)
+            ? result
+            : ConversionHelpers.UnsetValue;
 }

--- a/src/XamlConverters.Avalonia/BoolNegationConverter.cs
+++ b/src/XamlConverters.Avalonia/BoolNegationConverter.cs
@@ -12,8 +12,13 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class BoolNegationConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => !ConversionHelpers.IsTrue(value, culture);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        !ConversionHelpers.IsTrue(value, culture);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => !ConversionHelpers.IsTrue(value, culture);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => !ConversionHelpers.IsTrue(value, culture);
 }

--- a/src/XamlConverters.Avalonia/BoolToOpacityConverter.cs
+++ b/src/XamlConverters.Avalonia/BoolToOpacityConverter.cs
@@ -15,12 +15,12 @@ public sealed class BoolToOpacityConverter : IValueConverter
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var falseOpacity = ConversionHelpers.TryDecimal(parameter, culture, out var opacity)
-            ? Math.Clamp((double)opacity, 0d, 1d)
-            : 0d;
-        return ConversionHelpers.IsTrue(value, culture) ? 1d : falseOpacity;
+            ? Math.Clamp((double)opacity, 0D, 1D)
+            : 0D;
+        return ConversionHelpers.IsTrue(value, culture) ? 1D : falseOpacity;
     }
 
     /// <inheritdoc/>
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryDecimal(value, culture, out var opacity) && opacity >= 1m;
+        ConversionHelpers.TryDecimal(value, culture, out var opacity) && opacity >= 1M;
 }

--- a/src/XamlConverters.Avalonia/BoolToVisibilityConverterNegate.cs
+++ b/src/XamlConverters.Avalonia/BoolToVisibilityConverterNegate.cs
@@ -16,5 +16,9 @@ public sealed class BoolToVisibilityConverterNegate : IValueConverter
         !ConversionHelpers.IsTrue(value, culture);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => !ConversionHelpers.IsTrue(value, culture);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => !ConversionHelpers.IsTrue(value, culture);
 }

--- a/src/XamlConverters.Avalonia/BooleanToValueConverter.cs
+++ b/src/XamlConverters.Avalonia/BooleanToValueConverter.cs
@@ -18,9 +18,16 @@ public sealed class BooleanToValueConverter : IValueConverter
     public object? FalseValue { get; set; }
 
     /// <inheritdoc/>
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.IsTrue(value, culture) ? TrueValue : FalseValue;
+    public object? Convert(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.IsTrue(value, culture) ? TrueValue : FalseValue;
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Equals(value, TrueValue);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Equals(value, TrueValue);
 }

--- a/src/XamlConverters.Avalonia/BooleanXorConverter.cs
+++ b/src/XamlConverters.Avalonia/BooleanXorConverter.cs
@@ -15,9 +15,15 @@ public sealed class BooleanXorConverter : IMultiValueConverter
     private const int ParityDivisor = 2;
 
     /// <inheritdoc/>
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    public object Convert(
+        IList<object?> values,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         ArgumentNullException.ThrowIfNull(values);
-        return values.Count(value => !ConversionHelpers.IsUnset(value) && ConversionHelpers.IsTrue(value, culture)) % ParityDivisor == 1;
+        return values.Count(value =>
+                !ConversionHelpers.IsUnset(value) && ConversionHelpers.IsTrue(value, culture)) % ParityDivisor
+            == 1;
     }
 }

--- a/src/XamlConverters.Avalonia/ByteArrayToBase64Converter.cs
+++ b/src/XamlConverters.Avalonia/ByteArrayToBase64Converter.cs
@@ -12,10 +12,15 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class ByteArrayToBase64Converter : IValueConverter
 {
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        ConvertCore(value, targetType);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConvertCore(value, targetType);
 
     /// <summary>Converts between byte arrays and Base64 text.</summary>
     /// <param name="value">The source value.</param>
@@ -28,7 +33,9 @@ public sealed class ByteArrayToBase64Converter : IValueConverter
             return System.Convert.ToBase64String(bytes);
         }
 
-        if (value is not string text || (targetType != typeof(byte[]) && targetType != typeof(object)))
+        if (
+            value is not string text
+            || (targetType != typeof(byte[]) && targetType != typeof(object)))
         {
             return ConversionHelpers.DoNothing;
         }

--- a/src/XamlConverters.Avalonia/ClampConverter.cs
+++ b/src/XamlConverters.Avalonia/ClampConverter.cs
@@ -37,9 +37,16 @@ public sealed class ClampConverter : IValueConverter
             _ = decimal.TryParse(parts[1], NumberStyles.Any, culture, out maximum);
         }
 
-        return ConversionHelpers.ConvertDecimal(Math.Clamp(number, Math.Min(minimum, maximum), Math.Max(minimum, maximum)), targetType, culture);
+        return ConversionHelpers.ConvertDecimal(
+            Math.Clamp(number, Math.Min(minimum, maximum), Math.Max(minimum, maximum)),
+            targetType,
+            culture);
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Convert(value, targetType, parameter, culture);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Convert(value, targetType, parameter, culture);
 }

--- a/src/XamlConverters.Avalonia/CollectionContainsConverter.cs
+++ b/src/XamlConverters.Avalonia/CollectionContainsConverter.cs
@@ -20,7 +20,8 @@ public sealed class CollectionContainsConverter : IValueConverter
         if (value is string text)
         {
             var searchText = parameter?.ToString();
-            return searchText is not null && culture.CompareInfo.IndexOf(text, searchText, CompareOptions.None) >= 0;
+            return searchText is not null
+                && culture.CompareInfo.IndexOf(text, searchText, CompareOptions.None) >= 0;
         }
 
         if (value is not IEnumerable enumerable)
@@ -40,7 +41,11 @@ public sealed class CollectionContainsConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Determines whether a collection item equals the requested value directly or after conversion.</summary>
     /// <param name="item">The collection item.</param>
@@ -49,8 +54,13 @@ public sealed class CollectionContainsConverter : IValueConverter
     /// <returns><see langword="true"/> when the values are equal; otherwise, <see langword="false"/>.</returns>
     private static bool ItemsEqual(object? item, object? requestedValue, CultureInfo culture) =>
         Equals(item, requestedValue)
-        || (item is not null
+        || (
+            item is not null
             && requestedValue is not null
-            && ConversionHelpers.TryConvert(requestedValue, item.GetType(), culture, out var converted)
+            && ConversionHelpers.TryConvert(
+                requestedValue,
+                item.GetType(),
+                culture,
+                out var converted)
             && Equals(item, converted));
 }

--- a/src/XamlConverters.Avalonia/CollectionFirstOrDefaultConverter.cs
+++ b/src/XamlConverters.Avalonia/CollectionFirstOrDefaultConverter.cs
@@ -37,5 +37,9 @@ public sealed class CollectionFirstOrDefaultConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/CollectionItemConverter.cs
+++ b/src/XamlConverters.Avalonia/CollectionItemConverter.cs
@@ -22,7 +22,8 @@ public sealed class CollectionItemConverter : IValueConverter
                 : ConversionHelpers.DoNothing;
         }
 
-        if (!ConversionHelpers.TryConvert(parameter, typeof(int), culture, out var convertedIndex)
+        if (
+            !ConversionHelpers.TryConvert(parameter, typeof(int), culture, out var convertedIndex)
             || convertedIndex is not int index
             || index < 0)
         {
@@ -34,11 +35,17 @@ public sealed class CollectionItemConverter : IValueConverter
             return index < list.Count ? list[index] : ConversionHelpers.DoNothing;
         }
 
-        return value is not IEnumerable enumerable ? ConversionHelpers.DoNothing : GetItem(enumerable, index);
+        return value is not IEnumerable enumerable
+            ? ConversionHelpers.DoNothing
+            : GetItem(enumerable, index);
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Gets an item from an enumerable by index.</summary>
     /// <param name="enumerable">The enumerable source.</param>
@@ -49,10 +56,12 @@ public sealed class CollectionItemConverter : IValueConverter
         var currentIndex = 0;
         foreach (var item in enumerable)
         {
-            if (currentIndex++ == index)
+            if (currentIndex == index)
             {
                 return item;
             }
+
+            currentIndex++;
         }
 
         return ConversionHelpers.DoNothing;

--- a/src/XamlConverters.Avalonia/CollectionSizeToBoolConverter.cs
+++ b/src/XamlConverters.Avalonia/CollectionSizeToBoolConverter.cs
@@ -14,12 +14,23 @@ public sealed class CollectionSizeToBoolConverter : IValueConverter
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        var reverse = string.Equals(parameter?.ToString(), "reverse", StringComparison.OrdinalIgnoreCase);
-        var expected = !reverse && int.TryParse(parameter?.ToString(), NumberStyles.Integer, culture, out var parsed) ? parsed : 0;
+        var reverse = string.Equals(
+            parameter?.ToString(),
+            "reverse",
+            StringComparison.OrdinalIgnoreCase);
+        var expected =
+            !reverse
+            && int.TryParse(parameter?.ToString(), NumberStyles.Integer, culture, out var parsed)
+                ? parsed
+                : 0;
         var matches = ConversionHelpers.TryCount(value, out var count) && count == expected;
         return reverse ? !matches : matches;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/CollectionSizeToVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/CollectionSizeToVisibilityConverter.cs
@@ -19,5 +19,9 @@ public sealed class CollectionSizeToVisibilityConverter : IValueConverter
         Equals(_countConverter.Convert(value, typeof(bool), parameter, culture), true);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ComparisonConverter.cs
+++ b/src/XamlConverters.Avalonia/ComparisonConverter.cs
@@ -39,7 +39,11 @@ public sealed partial class ComparisonConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Compares a value with the textual right operand.</summary>
     /// <param name="value">The left operand.</param>
@@ -48,8 +52,11 @@ public sealed partial class ComparisonConverter : IValueConverter
     /// <returns>A value indicating the operands' relative order.</returns>
     private static int Compare(object value, string rightText, CultureInfo culture)
     {
-        return ConversionHelpers.TryDecimal(value, culture, out var left) &&
-            decimal.TryParse(rightText, NumberStyles.Any, culture, out var right) ? left.CompareTo(right) : string.Compare(value.ToString(), rightText, StringComparison.OrdinalIgnoreCase);
+        return
+            ConversionHelpers.TryDecimal(value, culture, out var left)
+            && decimal.TryParse(rightText, NumberStyles.Any, culture, out var right)
+                ? left.CompareTo(right)
+                : string.Compare(value.ToString(), rightText, StringComparison.OrdinalIgnoreCase);
     }
 
     [GeneratedRegex("^(?<invert>!?)(?<op>>=|<=|==|!=|>|<)\\s*(?<rhs>.+)$", RegexOptions.Compiled)]

--- a/src/XamlConverters.Avalonia/ComparisonToVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/ComparisonToVisibilityConverter.cs
@@ -19,5 +19,9 @@ public sealed class ComparisonToVisibilityConverter : IValueConverter
         Equals(_comparison.Convert(value, typeof(bool), parameter, culture), true);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/CountToBooleanConverter.cs
+++ b/src/XamlConverters.Avalonia/CountToBooleanConverter.cs
@@ -19,10 +19,16 @@ public sealed class CountToBooleanConverter : IValueConverter
             return false;
         }
 
-        var expression = string.IsNullOrWhiteSpace(parameter?.ToString()) ? ">0" : parameter!.ToString()!;
+        var expression = string.IsNullOrWhiteSpace(parameter?.ToString())
+            ? ">0"
+            : parameter!.ToString()!;
         return ConversionHelpers.Compare(count, expression, culture);
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/CountToVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/CountToVisibilityConverter.cs
@@ -19,5 +19,9 @@ public sealed class CountToVisibilityConverter : IValueConverter
         Equals(_countConverter.Convert(value, typeof(bool), parameter, culture), true);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/DateTimeFormatConverter.cs
+++ b/src/XamlConverters.Avalonia/DateTimeFormatConverter.cs
@@ -28,6 +28,12 @@ public sealed class DateTimeFormatConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryConvert(value, targetType, culture, out var result) ? result : ConversionHelpers.UnsetValue;
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
+        ConversionHelpers.TryConvert(value, targetType, culture, out var result)
+            ? result
+            : ConversionHelpers.UnsetValue;
 }

--- a/src/XamlConverters.Avalonia/DoubleToCurrencyStringConverter.cs
+++ b/src/XamlConverters.Avalonia/DoubleToCurrencyStringConverter.cs
@@ -13,10 +13,16 @@ public sealed class DoubleToCurrencyStringConverter : IValueConverter
 {
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryDecimal(value, culture, out var amount) ? amount.ToString(parameter?.ToString() ?? "C", culture) : 0m.ToString("C", culture);
+        ConversionHelpers.TryDecimal(value, culture, out var amount)
+            ? amount.ToString(parameter?.ToString() ?? "C", culture)
+            : 0M.ToString("C", culture);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
         decimal.TryParse(value?.ToString(), NumberStyles.Currency, culture, out var amount)
             ? ConversionHelpers.ConvertDecimal(amount, targetType, culture)
             : ConversionHelpers.UnsetValue;

--- a/src/XamlConverters.Avalonia/EnumConverter.cs
+++ b/src/XamlConverters.Avalonia/EnumConverter.cs
@@ -16,12 +16,20 @@ public sealed class EnumConverter : IValueConverter
     {
         ArgumentNullException.ThrowIfNull(targetType);
         var enumType = (parameter as Type) ?? targetType;
-        return enumType.IsEnum && ConversionHelpers.TryConvert(value, enumType, culture, out var result)
-            ? result
-            : ConversionHelpers.UnsetValue;
+        return
+            enumType.IsEnum
+            && ConversionHelpers.TryConvert(value, enumType, culture, out var result)
+                ? result
+                : ConversionHelpers.UnsetValue;
     }
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryConvert(value, targetType, culture, out var result) ? result : ConversionHelpers.UnsetValue;
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
+        ConversionHelpers.TryConvert(value, targetType, culture, out var result)
+            ? result
+            : ConversionHelpers.UnsetValue;
 }

--- a/src/XamlConverters.Avalonia/EnumHasFlagConverter.cs
+++ b/src/XamlConverters.Avalonia/EnumHasFlagConverter.cs
@@ -14,8 +14,13 @@ public sealed class EnumHasFlagConverter : IValueConverter
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is not Enum enumValue
-            || !ConversionHelpers.TryConvert(parameter, enumValue.GetType(), culture, out var convertedFlag)
+        if (
+            value is not Enum enumValue
+            || !ConversionHelpers.TryConvert(
+                parameter,
+                enumValue.GetType(),
+                culture,
+                out var convertedFlag)
             || convertedFlag is not Enum flag)
         {
             return false;
@@ -27,7 +32,11 @@ public sealed class EnumHasFlagConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Converts an enum value to its unsigned bit representation.</summary>
     /// <param name="value">The enum value.</param>

--- a/src/XamlConverters.Avalonia/EnumToBooleanConverter.cs
+++ b/src/XamlConverters.Avalonia/EnumToBooleanConverter.cs
@@ -13,14 +13,24 @@ public sealed class EnumToBooleanConverter : IValueConverter
 {
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is not null && parameter is not null && string.Equals(value.ToString(), parameter.ToString(), StringComparison.OrdinalIgnoreCase);
+        value is not null
+        && parameter is not null
+        && string.Equals(
+            value.ToString(),
+            parameter.ToString(),
+            StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         ArgumentNullException.ThrowIfNull(targetType);
-        return ConversionHelpers.IsTrue(value, culture) && parameter is not null && targetType.IsEnum
-            ? Enum.Parse(targetType, parameter.ToString()!, ignoreCase: true)
-            : ConversionHelpers.DoNothing;
+        return
+            ConversionHelpers.IsTrue(value, culture) && parameter is not null && targetType.IsEnum
+                ? Enum.Parse(targetType, parameter.ToString()!, ignoreCase: true)
+                : ConversionHelpers.DoNothing;
     }
 }

--- a/src/XamlConverters.Avalonia/EnumToDescriptionConverter.cs
+++ b/src/XamlConverters.Avalonia/EnumToDescriptionConverter.cs
@@ -21,10 +21,18 @@ public sealed class EnumToDescriptionConverter : IValueConverter
         }
 
         var member = enumValue.GetType().GetMember(enumValue.ToString()).FirstOrDefault();
-        return member?.GetCustomAttributes(typeof(DescriptionAttribute), false).OfType<DescriptionAttribute>().FirstOrDefault()?.Description
+        return member
+                ?.GetCustomAttributes(typeof(DescriptionAttribute), false)
+                .OfType<DescriptionAttribute>()
+                .FirstOrDefault()
+                ?.Description
             ?? enumValue.ToString();
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/EnumValuesConverter.cs
+++ b/src/XamlConverters.Avalonia/EnumValuesConverter.cs
@@ -16,11 +16,13 @@ public sealed class EnumValuesConverter : IValueConverter
     {
         var enumType = (parameter as Type) ?? (value as Type) ?? value?.GetType();
         enumType = enumType is null ? null : Nullable.GetUnderlyingType(enumType) ?? enumType;
-        return enumType?.IsEnum == true
-            ? Enum.GetValues(enumType)
-            : ConversionHelpers.DoNothing;
+        return enumType?.IsEnum == true ? Enum.GetValues(enumType) : ConversionHelpers.DoNothing;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/EnumerableToStringConverter.cs
+++ b/src/XamlConverters.Avalonia/EnumerableToStringConverter.cs
@@ -34,14 +34,19 @@ public sealed class EnumerableToStringConverter : IValueConverter
         var values = new List<string>();
         foreach (var item in enumerable)
         {
-            values.Add(item is IFormattable formattable
-                ? formattable.ToString(null, culture)
-                : item?.ToString() ?? string.Empty);
+            values.Add(
+                item is IFormattable formattable
+                    ? formattable.ToString(null, culture)
+                    : item?.ToString() ?? string.Empty);
         }
 
         return string.Join(separator, values);
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/EqualityConverter.cs
+++ b/src/XamlConverters.Avalonia/EqualityConverter.cs
@@ -22,12 +22,23 @@ public sealed class EqualityConverter : IValueConverter
         var text = parameter?.ToString() ?? string.Empty;
         var invert = text.StartsWith("!", StringComparison.Ordinal);
         var candidate = invert ? text[1..] : parameter;
-        var result = ConversionHelpers.TryConvert(candidate, value.GetType(), culture, out var converted)
+        var result = ConversionHelpers.TryConvert(
+            candidate,
+            value.GetType(),
+            culture,
+            out var converted)
             ? Equals(value, converted)
-            : string.Equals(value.ToString(), candidate?.ToString(), StringComparison.OrdinalIgnoreCase);
+            : string.Equals(
+                value.ToString(),
+                candidate?.ToString(),
+                StringComparison.OrdinalIgnoreCase);
         return invert ? !result : result;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/FallbackBrushConverter.cs
+++ b/src/XamlConverters.Avalonia/FallbackBrushConverter.cs
@@ -16,14 +16,19 @@ public sealed class FallbackBrushConverter : IValueConverter
     public IBrush Fallback { get; set; } = Brushes.Red;
 
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value switch
-    {
-        IBrush brush => brush,
-        Color color => new SolidColorBrush(color),
-        _ when ColorHelpers.TryColor(parameter, out var parsed) => new SolidColorBrush(parsed),
-        _ => Fallback,
-    };
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value switch
+        {
+            IBrush brush => brush,
+            Color color => new SolidColorBrush(color),
+            _ when ColorHelpers.TryColor(parameter, out var parsed) => new SolidColorBrush(parsed),
+            _ => Fallback,
+        };
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/GuidConverter.cs
+++ b/src/XamlConverters.Avalonia/GuidConverter.cs
@@ -12,10 +12,15 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class GuidConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType, parameter, culture);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        ConvertCore(value, targetType, parameter, culture);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType, parameter, culture);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConvertCore(value, targetType, parameter, culture);
 
     /// <summary>Converts between GUID values and text.</summary>
     /// <param name="value">The source value.</param>
@@ -23,7 +28,11 @@ public sealed class GuidConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The conversion culture.</param>
     /// <returns>The converted value or an Avalonia binding sentinel.</returns>
-    private static object ConvertCore(object? value, Type targetType, object? parameter, CultureInfo culture)
+    private static object ConvertCore(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         if (value is Guid guid)
         {
@@ -52,7 +61,11 @@ public sealed class GuidConverter : IValueConverter
             return new Guid(bytes);
         }
 
-        return ConversionHelpers.TryConvert(value, targetType == typeof(string) ? typeof(Guid) : targetType, culture, out var converted)
+        return ConversionHelpers.TryConvert(
+            value,
+            targetType == typeof(string) ? typeof(Guid) : targetType,
+            culture,
+            out var converted)
             ? converted!
             : ConversionHelpers.DoNothing;
     }

--- a/src/XamlConverters.Avalonia/HexStringToSolidColorBrushConverter.cs
+++ b/src/XamlConverters.Avalonia/HexStringToSolidColorBrushConverter.cs
@@ -14,9 +14,17 @@ public sealed class HexStringToSolidColorBrushConverter : IValueConverter
 {
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ColorHelpers.TryColor(value ?? parameter, out var color) ? new SolidColorBrush(color) : ConversionHelpers.UnsetValue;
+        ColorHelpers.TryColor(value ?? parameter, out var color)
+            ? new SolidColorBrush(color)
+            : ConversionHelpers.UnsetValue;
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is SolidColorBrush brush ? ColorHelpers.ToHex(brush.Color) : ConversionHelpers.UnsetValue;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
+        value is SolidColorBrush brush
+            ? ColorHelpers.ToHex(brush.Color)
+            : ConversionHelpers.UnsetValue;
 }

--- a/src/XamlConverters.Avalonia/IntToThicknessConverter.cs
+++ b/src/XamlConverters.Avalonia/IntToThicknessConverter.cs
@@ -46,9 +46,17 @@ public sealed class IntToThicknessConverter : IValueConverter
 
         var input = (double)number;
         var basis = parameter is Thickness thickness ? thickness : default;
-        return new Thickness(Left ? input : basis.Left, Top ? input : basis.Top, Right ? input : basis.Right, Bottom ? input : basis.Bottom);
+        return new Thickness(
+            Left ? input : basis.Left,
+            Top ? input : basis.Top,
+            Right ? input : basis.Right,
+            Bottom ? input : basis.Bottom);
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/IntToVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/IntToVisibilityConverter.cs
@@ -16,5 +16,9 @@ public sealed class IntToVisibilityConverter : IValueConverter
         ConversionHelpers.TryDecimal(value, culture, out var number) && number > 0;
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.IsTrue(value, culture) ? 1 : 0;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.IsTrue(value, culture) ? 1 : 0;
 }

--- a/src/XamlConverters.Avalonia/Internal/ConversionHelpers.cs
+++ b/src/XamlConverters.Avalonia/Internal/ConversionHelpers.cs
@@ -14,7 +14,10 @@ namespace CP.Xaml.Converters.Avalonia.Internal;
 internal static class ConversionHelpers
 {
     /// <summary>The parsers used for well-known non-BCL-convertible value types.</summary>
-    private static readonly Dictionary<Type, Func<string?, CultureInfo, (bool Success, object? Result)>> TextParsers = new()
+    private static readonly Dictionary<
+        Type,
+        Func<string?, CultureInfo, (bool Success, object? Result)>
+    > TextParsers = new()
     {
         [typeof(Guid)] = TryParseGuid,
         [typeof(Uri)] = TryParseUri,
@@ -32,9 +35,11 @@ internal static class ConversionHelpers
 
     /// <summary>Determines whether a value is an Avalonia binding sentinel.</summary>
     /// <param name="value">The value to inspect.</param>
-    /// <returns><see langword="true"/> for an unset or do-nothing sentinel; otherwise, <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> for an unset or do-nothing sentinel; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool IsUnset(object? value) =>
-        ReferenceEquals(value, AvaloniaProperty.UnsetValue) || ReferenceEquals(value, BindingOperations.DoNothing);
+        ReferenceEquals(value, AvaloniaProperty.UnsetValue)
+        || ReferenceEquals(value, BindingOperations.DoNothing);
 
     /// <summary>Determines whether a value is null or a binding sentinel.</summary>
     /// <param name="value">The value to inspect.</param>
@@ -47,7 +52,11 @@ internal static class ConversionHelpers
     /// <returns><see langword="true"/> when the value represents true; otherwise, <see langword="false"/>.</returns>
     public static bool IsTrue(object? value, CultureInfo culture)
     {
-        return value is bool boolean ? boolean : value is not null && bool.TryParse(Convert.ToString(value, culture), out var result) && result;
+        return value is bool boolean
+            ? boolean
+            : value is not null
+                && bool.TryParse(Convert.ToString(value, culture), out var result)
+                && result;
     }
 
     /// <summary>Attempts to convert a value to a requested type.</summary>
@@ -56,7 +65,11 @@ internal static class ConversionHelpers
     /// <param name="culture">The conversion culture.</param>
     /// <param name="result">The converted value when conversion succeeds.</param>
     /// <returns><see langword="true"/> when conversion succeeds; otherwise, <see langword="false"/>.</returns>
-    public static bool TryConvert(object? value, Type targetType, CultureInfo culture, out object? result)
+    public static bool TryConvert(
+        object? value,
+        Type targetType,
+        CultureInfo culture,
+        out object? result)
     {
         ArgumentNullException.ThrowIfNull(targetType);
 
@@ -127,7 +140,12 @@ internal static class ConversionHelpers
     /// <param name="culture">The conversion culture.</param>
     /// <param name="result">The converted result.</param>
     /// <returns><see langword="true"/> when a type converter succeeds; otherwise, <see langword="false"/>.</returns>
-    public static bool TryTypeConverters(object value, Type targetType, string? text, CultureInfo culture, out object? result)
+    public static bool TryTypeConverters(
+        object value,
+        Type targetType,
+        string? text,
+        CultureInfo culture,
+        out object? result)
     {
         var targetConverter = TypeDescriptor.GetConverter(targetType);
         if (targetConverter.CanConvertFrom(value.GetType()))
@@ -187,7 +205,9 @@ internal static class ConversionHelpers
     /// <param name="text">The text to parse.</param>
     /// <param name="culture">The parsing culture.</param>
     /// <returns>The parsing status and parsed result.</returns>
-    public static (bool Success, object? Result) TryParseDateTimeOffset(string? text, CultureInfo culture)
+    public static (bool Success, object? Result) TryParseDateTimeOffset(
+        string? text,
+        CultureInfo culture)
     {
         var success = DateTimeOffset.TryParse(text, culture, DateTimeStyles.None, out var value);
         return (success, success ? value : null);
@@ -231,7 +251,8 @@ internal static class ConversionHelpers
             result = Convert.ToDecimal(value, culture);
             return true;
         }
-        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
+        catch (Exception ex)
+            when (ex is FormatException or InvalidCastException or OverflowException)
         {
             result = default;
             return false;
@@ -263,33 +284,33 @@ internal static class ConversionHelpers
         switch (value)
         {
             case string text:
-                {
-                    count = text.Length;
-                    return true;
-                }
+            {
+                count = text.Length;
+                return true;
+            }
 
             case ICollection collection:
-                {
-                    count = collection.Count;
-                    return true;
-                }
+            {
+                count = collection.Count;
+                return true;
+            }
 
             case IEnumerable enumerable:
+            {
+                count = 0;
+                foreach (var unused in enumerable)
                 {
-                    count = 0;
-                    foreach (var unused in enumerable)
-                    {
-                        count++;
-                    }
-
-                    return true;
+                    count++;
                 }
+
+                return true;
+            }
 
             default:
-                {
-                    count = 0;
-                    return false;
-                }
+            {
+                count = 0;
+                return false;
+            }
         }
     }
 
@@ -303,8 +324,13 @@ internal static class ConversionHelpers
         expression = expression.Trim();
         foreach (var op in new[] { ">=", "<=", "==", "!=", ">", "<" })
         {
-            if (!expression.StartsWith(op, StringComparison.Ordinal) ||
-                !decimal.TryParse(expression.Substring(op.Length).Trim(), NumberStyles.Any, culture, out var right))
+            if (
+                !expression.StartsWith(op, StringComparison.Ordinal)
+                || !decimal.TryParse(
+                    expression.Substring(op.Length).Trim(),
+                    NumberStyles.Any,
+                    culture,
+                    out var right))
             {
                 continue;
             }
@@ -326,9 +352,15 @@ internal static class ConversionHelpers
 
     /// <summary>Determines whether an exception represents a recoverable conversion failure.</summary>
     /// <param name="exception">The exception to inspect.</param>
-    /// <returns><see langword="true"/> for a recoverable conversion failure; otherwise, <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> for a recoverable conversion failure; otherwise, <see langword="false"/>.
+    /// </returns>
     private static bool IsConversionException(Exception exception) =>
-        exception is ArgumentException or FormatException or InvalidCastException or NotSupportedException or OverflowException;
+        exception
+            is ArgumentException
+                or FormatException
+                or InvalidCastException
+                or NotSupportedException
+                or OverflowException;
 
     /// <summary>Attempts to parse a value through a registered textual parser.</summary>
     /// <param name="text">The text to parse.</param>
@@ -336,7 +368,11 @@ internal static class ConversionHelpers
     /// <param name="culture">The parsing culture.</param>
     /// <param name="result">The parsed result.</param>
     /// <returns><see langword="true"/> when parsing succeeds; otherwise, <see langword="false"/>.</returns>
-    private static bool TryParseKnownText(string? text, Type targetType, CultureInfo culture, out object? result)
+    private static bool TryParseKnownText(
+        string? text,
+        Type targetType,
+        CultureInfo culture,
+        out object? result)
     {
         if (TextParsers.TryGetValue(targetType, out var parser))
         {

--- a/src/XamlConverters.Avalonia/InvertSignConverter.cs
+++ b/src/XamlConverters.Avalonia/InvertSignConverter.cs
@@ -12,10 +12,15 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class InvertSignConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => Negate(value, targetType, culture);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        Negate(value, targetType, culture);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Negate(value, targetType, culture);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Negate(value, targetType, culture);
 
     /// <summary>Negates a numeric value.</summary>
     /// <param name="value">The value to negate.</param>

--- a/src/XamlConverters.Avalonia/InvertValueConverter.cs
+++ b/src/XamlConverters.Avalonia/InvertValueConverter.cs
@@ -14,8 +14,13 @@ public sealed class InvertValueConverter : IValueConverter
     private readonly InvertSignConverter _inner = new();
 
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => _inner.Convert(value, targetType, parameter, culture);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        _inner.Convert(value, targetType, parameter, culture);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => _inner.ConvertBack(value, targetType, parameter, culture);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => _inner.ConvertBack(value, targetType, parameter, culture);
 }

--- a/src/XamlConverters.Avalonia/IsGreaterThanOrEqualToConverter.cs
+++ b/src/XamlConverters.Avalonia/IsGreaterThanOrEqualToConverter.cs
@@ -12,14 +12,22 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class IsGreaterThanOrEqualToConverter : IValueConverter, IMultiValueConverter
 {
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => Compare(value, parameter, culture);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        Compare(value, parameter, culture);
 
     /// <inheritdoc/>
-    object IMultiValueConverter.Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
-        values.Count >= 2 && Compare(values[0], values[1], culture);
+    object IMultiValueConverter.Convert(
+        IList<object?> values,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => values.Count >= 2 && Compare(values[0], values[1], culture);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Compares two numeric values.</summary>
     /// <param name="left">The left operand.</param>
@@ -27,5 +35,7 @@ public sealed class IsGreaterThanOrEqualToConverter : IValueConverter, IMultiVal
     /// <param name="culture">The conversion culture.</param>
     /// <returns><see langword="true"/> when the left operand is greater than or equal to the right operand.</returns>
     private static bool Compare(object? left, object? right, CultureInfo culture) =>
-        ConversionHelpers.TryDecimal(left, culture, out var first) && ConversionHelpers.TryDecimal(right, culture, out var second) && first >= second;
+        ConversionHelpers.TryDecimal(left, culture, out var first)
+        && ConversionHelpers.TryDecimal(right, culture, out var second)
+        && first >= second;
 }

--- a/src/XamlConverters.Avalonia/LineStrokeLevelConverter.cs
+++ b/src/XamlConverters.Avalonia/LineStrokeLevelConverter.cs
@@ -24,8 +24,10 @@ public sealed class LineStrokeLevelConverter : IValueConverter
         }
 
         var parts = parameter?.ToString()?.Split('-');
-        if (parts is not { Length: >= RequiredThresholdCount } || !decimal.TryParse(parts[0], NumberStyles.Any, culture, out var low) ||
-            !decimal.TryParse(parts[1], NumberStyles.Any, culture, out var high))
+        if (
+            parts is not { Length: >= RequiredThresholdCount }
+            || !decimal.TryParse(parts[0], NumberStyles.Any, culture, out var low)
+            || !decimal.TryParse(parts[1], NumberStyles.Any, culture, out var high))
         {
             return Brushes.Red;
         }
@@ -39,5 +41,9 @@ public sealed class LineStrokeLevelConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/MathConverter.cs
+++ b/src/XamlConverters.Avalonia/MathConverter.cs
@@ -19,11 +19,18 @@ public sealed class MathConverter : IValueConverter, IMultiValueConverter
         Evaluate([value], targetType, parameter, culture);
 
     /// <inheritdoc/>
-    object? IMultiValueConverter.Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
-        Evaluate(values, targetType, parameter, culture);
+    object? IMultiValueConverter.Convert(
+        IList<object?> values,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Evaluate(values, targetType, parameter, culture);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Evaluates the configured arithmetic expression.</summary>
     /// <param name="values">The converter input values.</param>
@@ -31,7 +38,11 @@ public sealed class MathConverter : IValueConverter, IMultiValueConverter
     /// <param name="parameter">The arithmetic expression.</param>
     /// <param name="culture">The conversion culture.</param>
     /// <returns>The evaluated value or an Avalonia binding sentinel.</returns>
-    private object Evaluate(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    private object Evaluate(
+        IList<object?> values,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         var text = parameter?.ToString();
         if (string.IsNullOrWhiteSpace(text))
@@ -47,9 +58,18 @@ public sealed class MathConverter : IValueConverter, IMultiValueConverter
                 _expressions[text] = expression;
             }
 
-            return ConversionHelpers.ConvertDecimal(expression.Evaluate(values, culture), targetType, culture);
+            return ConversionHelpers.ConvertDecimal(
+                expression.Evaluate(values, culture),
+                targetType,
+                culture);
         }
-        catch (Exception ex) when (ex is ArgumentException or DivideByZeroException or FormatException or InvalidCastException or OverflowException)
+        catch (Exception ex)
+            when (ex
+                    is ArgumentException
+                        or DivideByZeroException
+                        or FormatException
+                        or InvalidCastException
+                        or OverflowException)
         {
             return ConversionHelpers.UnsetValue;
         }

--- a/src/XamlConverters.Avalonia/MathExpression.cs
+++ b/src/XamlConverters.Avalonia/MathExpression.cs
@@ -10,9 +10,6 @@ namespace CP.Xaml.Converters.Avalonia;
 /// <summary>Parses and evaluates arithmetic expressions over converter inputs.</summary>
 internal sealed class MathExpression
 {
-    /// <summary>The number of character aliases assigned to each positional variable.</summary>
-    private const int AliasesPerVariable = 2;
-
     /// <summary>The parsed expression root.</summary>
     private readonly Node _root;
 
@@ -29,12 +26,16 @@ internal sealed class MathExpression
     /// <param name="values">The converter input values.</param>
     /// <param name="culture">The culture used for numeric conversion.</param>
     /// <returns>The expression result.</returns>
-    public decimal Evaluate(IList<object?> values, CultureInfo culture) => _root.Evaluate(values, culture);
+    public decimal Evaluate(IList<object?> values, CultureInfo culture) =>
+        _root.Evaluate(values, culture);
 
     /// <summary>Parses expression tokens into an expression tree.</summary>
     /// <param name="text">The expression text.</param>
     private sealed class Parser(string text)
     {
+        /// <summary>The number of character aliases assigned to each positional variable.</summary>
+        private const int AliasesPerVariable = 2;
+
         /// <summary>The current parser position.</summary>
         private int _position;
 
@@ -44,7 +45,9 @@ internal sealed class MathExpression
         {
             var node = ParseExpression();
             SkipWhitespace();
-            return _position == text.Length ? node : throw new ArgumentException("Unexpected expression text.");
+            return _position == text.Length
+                ? node
+                : throw new ArgumentException("Unexpected expression text.");
         }
 
         /// <summary>Parses an addition or subtraction expression.</summary>
@@ -93,10 +96,13 @@ internal sealed class MathExpression
             if (TryRead('('))
             {
                 var expression = ParseExpression();
-                return TryRead(')') ? expression : throw new ArgumentException("Missing closing parenthesis.");
+                return TryRead(')')
+                    ? expression
+                    : throw new ArgumentException("Missing closing parenthesis.");
             }
 
-            return (Node?)ParseNamedVariable() ?? (TryRead('{') ? ParseIndexedVariable() : ParseNumber());
+            return (Node?)ParseNamedVariable()
+                ?? (TryRead('{') ? ParseIndexedVariable() : ParseNumber());
         }
 
         /// <summary>Parses a named positional variable when one is present.</summary>
@@ -109,7 +115,9 @@ internal sealed class MathExpression
                 return null;
             }
 
-            var index = variableAliases.IndexOf(text[_position++]) / AliasesPerVariable;
+            var alias = text[_position];
+            _position++;
+            var index = variableAliases.IndexOf(alias) / AliasesPerVariable;
             return new Variable(index);
         }
 
@@ -134,20 +142,27 @@ internal sealed class MathExpression
         private Constant ParseNumber()
         {
             var numberStart = _position;
-            while (_position < text.Length && (char.IsDigit(text[_position]) || text[_position] is '.' or ','))
+            while (
+                _position < text.Length
+                && (char.IsDigit(text[_position]) || text[_position] is '.' or ','))
             {
                 _position++;
             }
 
             var number = text.Substring(numberStart, _position - numberStart);
-            return decimal.TryParse(number, NumberStyles.Any, CultureInfo.InvariantCulture, out var value)
+            return decimal.TryParse(
+                number,
+                NumberStyles.Any,
+                CultureInfo.InvariantCulture,
+                out var value)
                 ? new Constant(value)
                 : throw new ArgumentException("Expected a number or variable.");
         }
 
         /// <summary>Consumes the expected character when it is next in the input.</summary>
         /// <param name="expected">The character to consume.</param>
-        /// <returns><see langword="true"/> when the character was consumed; otherwise, <see langword="false"/>.</returns>
+        /// <returns><see langword="true"/> when the character was consumed; otherwise, <see langword="false"/>.
+        /// </returns>
         private bool TryRead(char expected)
         {
             SkipWhitespace();
@@ -194,7 +209,8 @@ internal sealed class MathExpression
     {
         /// <inheritdoc/>
         public override decimal Evaluate(IList<object?> values, CultureInfo culture) =>
-            Index < values.Count && ConversionHelpers.TryDecimal(values[Index], culture, out var value)
+            Index < values.Count
+            && ConversionHelpers.TryDecimal(values[Index], culture, out var value)
                 ? value
                 : throw new ArgumentException("Expression variable is unavailable or non-numeric.");
     }
@@ -204,7 +220,8 @@ internal sealed class MathExpression
     private sealed record Unary(Node Operand) : Node
     {
         /// <inheritdoc/>
-        public override decimal Evaluate(IList<object?> values, CultureInfo culture) => -Operand.Evaluate(values, culture);
+        public override decimal Evaluate(IList<object?> values, CultureInfo culture) =>
+            -Operand.Evaluate(values, culture);
     }
 
     /// <summary>Represents a binary arithmetic operation.</summary>

--- a/src/XamlConverters.Avalonia/MultiBooleanAndConverter.cs
+++ b/src/XamlConverters.Avalonia/MultiBooleanAndConverter.cs
@@ -12,9 +12,16 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class MultiBooleanAndConverter : IMultiValueConverter
 {
     /// <inheritdoc/>
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    public object Convert(
+        IList<object?> values,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         ArgumentNullException.ThrowIfNull(values);
-        return values.Count > 0 && values.Where(value => !ConversionHelpers.IsUnset(value)).All(value => ConversionHelpers.IsTrue(value, culture));
+        return values.Count > 0
+            && values
+                .Where(value => !ConversionHelpers.IsUnset(value))
+                .All(value => ConversionHelpers.IsTrue(value, culture));
     }
 }

--- a/src/XamlConverters.Avalonia/MultiConverter.cs
+++ b/src/XamlConverters.Avalonia/MultiConverter.cs
@@ -33,5 +33,9 @@ public sealed class MultiConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/MultiplierConverter.cs
+++ b/src/XamlConverters.Avalonia/MultiplierConverter.cs
@@ -12,10 +12,15 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class MultiplierConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => Apply(value, parameter, targetType, culture, divide: false);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        Apply(value, parameter, targetType, culture, divide: false);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Apply(value, parameter, targetType, culture, divide: true);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Apply(value, parameter, targetType, culture, divide: true);
 
     /// <summary>Multiplies or divides a numeric value by the converter parameter.</summary>
     /// <param name="value">The source value.</param>
@@ -24,14 +29,24 @@ public sealed class MultiplierConverter : IValueConverter
     /// <param name="culture">The conversion culture.</param>
     /// <param name="divide">Whether to divide instead of multiply.</param>
     /// <returns>The calculated value or an Avalonia binding sentinel.</returns>
-    private static object Apply(object? value, object? parameter, Type targetType, CultureInfo culture, bool divide)
+    private static object Apply(
+        object? value,
+        object? parameter,
+        Type targetType,
+        CultureInfo culture,
+        bool divide)
     {
-        if (!ConversionHelpers.TryDecimal(value, culture, out var number) ||
-            !ConversionHelpers.TryDecimal(parameter, culture, out var multiplier) || (divide && multiplier == 0))
+        if (
+            !ConversionHelpers.TryDecimal(value, culture, out var number)
+            || !ConversionHelpers.TryDecimal(parameter, culture, out var multiplier)
+            || (divide && multiplier == 0))
         {
             return ConversionHelpers.UnsetValue;
         }
 
-        return ConversionHelpers.ConvertDecimal(divide ? number / multiplier : number * multiplier, targetType, culture);
+        return ConversionHelpers.ConvertDecimal(
+            divide ? number / multiplier : number * multiplier,
+            targetType,
+            culture);
     }
 }

--- a/src/XamlConverters.Avalonia/NullCoalesceConverter.cs
+++ b/src/XamlConverters.Avalonia/NullCoalesceConverter.cs
@@ -12,9 +12,16 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class NullCoalesceConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.IsNullLike(value) ? parameter : value;
+    public object? Convert(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.IsNullLike(value) ? parameter : value;
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/NullToBoolConverter.cs
+++ b/src/XamlConverters.Avalonia/NullToBoolConverter.cs
@@ -28,5 +28,9 @@ public sealed class NullToBoolConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/NullToVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/NullToVisibilityConverter.cs
@@ -15,8 +15,9 @@ public sealed class NullToVisibilityConverter : IValueConverter
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var show = ConversionHelpers.IsNullLike(value);
-        if (string.Equals(parameter?.ToString(), "inverse", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(parameter?.ToString(), "invert", StringComparison.OrdinalIgnoreCase))
+        if (
+            string.Equals(parameter?.ToString(), "inverse", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(parameter?.ToString(), "invert", StringComparison.OrdinalIgnoreCase))
         {
             show = !show;
         }
@@ -25,5 +26,9 @@ public sealed class NullToVisibilityConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/NumberFormatConverter.cs
+++ b/src/XamlConverters.Avalonia/NumberFormatConverter.cs
@@ -24,8 +24,7 @@ public sealed class NumberFormatConverter : IValueConverter
         TypeCode.Int64,
         TypeCode.Decimal,
         TypeCode.Double,
-        TypeCode.Single,
-    ];
+        TypeCode.Single,];
 
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/XamlConverters.Avalonia/ObjectEqualsParameterConverter.cs
+++ b/src/XamlConverters.Avalonia/ObjectEqualsParameterConverter.cs
@@ -26,5 +26,9 @@ public sealed class ObjectEqualsParameterConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ObjectToTypeNameConverter.cs
+++ b/src/XamlConverters.Avalonia/ObjectToTypeNameConverter.cs
@@ -20,9 +20,15 @@ public sealed class ObjectToTypeNameConverter : IValueConverter
         }
 
         var type = value.GetType();
-        return string.Equals(parameter?.ToString(), "full", StringComparison.OrdinalIgnoreCase) ? type.FullName ?? type.Name : type.Name;
+        return string.Equals(parameter?.ToString(), "full", StringComparison.OrdinalIgnoreCase)
+            ? type.FullName ?? type.Name
+            : type.Name;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/PercentageConverter.cs
+++ b/src/XamlConverters.Avalonia/PercentageConverter.cs
@@ -12,7 +12,7 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class PercentageConverter : IValueConverter
 {
     /// <summary>The divisor used to convert a percentage to a factor.</summary>
-    private const decimal PercentageDivisor = 100m;
+    private const decimal PercentageDivisor = 100M;
 
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -34,9 +34,16 @@ public sealed class PercentageConverter : IValueConverter
             return ConversionHelpers.UnsetValue;
         }
 
-        return ConversionHelpers.ConvertDecimal(number * (percentage ? factor / PercentageDivisor : factor), targetType, culture);
+        return ConversionHelpers.ConvertDecimal(
+            number * (percentage ? factor / PercentageDivisor : factor),
+            targetType,
+            culture);
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/RoundingConverter.cs
+++ b/src/XamlConverters.Avalonia/RoundingConverter.cs
@@ -25,10 +25,23 @@ public sealed class RoundingConverter : IValueConverter
             return ConversionHelpers.UnsetValue;
         }
 
-        var digits = int.TryParse(parameter?.ToString(), NumberStyles.Integer, culture, out var parsed) ? Math.Clamp(parsed, 0, MaximumDecimalDigits) : 0;
-        return ConversionHelpers.ConvertDecimal(Math.Round(number, digits, Mode), targetType, culture);
+        var digits = int.TryParse(
+            parameter?.ToString(),
+            NumberStyles.Integer,
+            culture,
+            out var parsed)
+            ? Math.Clamp(parsed, 0, MaximumDecimalDigits)
+            : 0;
+        return ConversionHelpers.ConvertDecimal(
+            Math.Round(number, digits, Mode),
+            targetType,
+            culture);
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/StringFormatConverter.cs
+++ b/src/XamlConverters.Avalonia/StringFormatConverter.cs
@@ -25,9 +25,15 @@ public sealed class StringFormatConverter : IValueConverter
             return string.Format(culture, format, value);
         }
 
-        return value is IFormattable formattable ? formattable.ToString(format, culture) ?? string.Empty : value?.ToString() ?? string.Empty;
+        return value is IFormattable formattable
+            ? formattable.ToString(format, culture) ?? string.Empty
+            : value?.ToString() ?? string.Empty;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/StringNullOrEmptyToBoolConverter.cs
+++ b/src/XamlConverters.Avalonia/StringNullOrEmptyToBoolConverter.cs
@@ -15,10 +15,16 @@ public sealed class StringNullOrEmptyToBoolConverter : IValueConverter
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var result = !string.IsNullOrEmpty(value as string);
-        var invert = parameter is true || string.Equals(parameter?.ToString(), "invert", StringComparison.OrdinalIgnoreCase);
+        var invert =
+            parameter is true
+            || string.Equals(parameter?.ToString(), "invert", StringComparison.OrdinalIgnoreCase);
         return invert ? !result : result;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/StringNullOrEmptyToVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/StringNullOrEmptyToVisibilityConverter.cs
@@ -16,7 +16,9 @@ public sealed class StringNullOrEmptyToVisibilityConverter : IValueConverter
     {
         var tokens = parameter?.ToString() ?? string.Empty;
         var show = !string.IsNullOrEmpty(value as string);
-        if (tokens.Contains("invert", StringComparison.OrdinalIgnoreCase) || string.Equals(tokens, "true", StringComparison.OrdinalIgnoreCase))
+        if (
+            tokens.Contains("invert", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(tokens, "true", StringComparison.OrdinalIgnoreCase))
         {
             show = !show;
         }
@@ -25,5 +27,9 @@ public sealed class StringNullOrEmptyToVisibilityConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ThicknessUniformConverter.cs
+++ b/src/XamlConverters.Avalonia/ThicknessUniformConverter.cs
@@ -35,12 +35,17 @@ public sealed class ThicknessUniformConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Determines whether text contains either of two characters.</summary>
     /// <param name="text">The text to search.</param>
     /// <param name="first">The first character.</param>
     /// <param name="second">The second character.</param>
     /// <returns><see langword="true"/> when either character is present; otherwise, <see langword="false"/>.</returns>
-    private static bool ContainsEither(string text, char first, char second) => text.Contains(first) || text.Contains(second);
+    private static bool ContainsEither(string text, char first, char second) =>
+        text.Contains(first) || text.Contains(second);
 }

--- a/src/XamlConverters.Avalonia/TimeSpanFormatConverter.cs
+++ b/src/XamlConverters.Avalonia/TimeSpanFormatConverter.cs
@@ -16,9 +16,17 @@ public sealed class TimeSpanFormatConverter : IValueConverter
 
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is TimeSpan timeSpan ? timeSpan.ToString(parameter?.ToString() ?? Format, culture) : string.Empty;
+        value is TimeSpan timeSpan
+            ? timeSpan.ToString(parameter?.ToString() ?? Format, culture)
+            : string.Empty;
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryConvert(value, targetType, culture, out var result) ? result : ConversionHelpers.UnsetValue;
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
+        ConversionHelpers.TryConvert(value, targetType, culture, out var result)
+            ? result
+            : ConversionHelpers.UnsetValue;
 }

--- a/src/XamlConverters.Avalonia/ToLowerConverter.cs
+++ b/src/XamlConverters.Avalonia/ToLowerConverter.cs
@@ -12,8 +12,16 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class ToLowerConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value?.ToString()?.ToLower(culture);
+    public object? Convert(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => value?.ToString()?.ToLower(culture);
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ToUpperConverter.cs
+++ b/src/XamlConverters.Avalonia/ToUpperConverter.cs
@@ -12,8 +12,16 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class ToUpperConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value?.ToString()?.ToUpper(culture);
+    public object? Convert(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => value?.ToString()?.ToUpper(culture);
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/TrimConverter.cs
+++ b/src/XamlConverters.Avalonia/TrimConverter.cs
@@ -11,8 +11,16 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class TrimConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value?.ToString()?.Trim();
+    public object? Convert(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => value?.ToString()?.Trim();
 
     /// <inheritdoc/>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => value?.ToString()?.Trim();
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => value?.ToString()?.Trim();
 }

--- a/src/XamlConverters.Avalonia/TypeMatchConverter.cs
+++ b/src/XamlConverters.Avalonia/TypeMatchConverter.cs
@@ -38,7 +38,11 @@ public sealed class TypeMatchConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Determines whether any supported type name matches the requested name.</summary>
     /// <param name="type">The type to inspect.</param>
@@ -47,5 +51,8 @@ public sealed class TypeMatchConverter : IValueConverter
     private static bool MatchesName(Type type, string expectedName) =>
         string.Equals(type.Name, expectedName, StringComparison.OrdinalIgnoreCase)
         || string.Equals(type.FullName, expectedName, StringComparison.OrdinalIgnoreCase)
-        || string.Equals(type.AssemblyQualifiedName, expectedName, StringComparison.OrdinalIgnoreCase);
+        || string.Equals(
+            type.AssemblyQualifiedName,
+            expectedName,
+            StringComparison.OrdinalIgnoreCase);
 }

--- a/src/XamlConverters.Avalonia/UriConverter.cs
+++ b/src/XamlConverters.Avalonia/UriConverter.cs
@@ -12,10 +12,15 @@ namespace CP.Xaml.Converters.Avalonia;
 public sealed class UriConverter : IValueConverter
 {
     /// <inheritdoc/>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType, parameter);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        ConvertCore(value, targetType, parameter);
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType, parameter);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConvertCore(value, targetType, parameter);
 
     /// <summary>Converts between URI values and text.</summary>
     /// <param name="value">The source value.</param>

--- a/src/XamlConverters.Avalonia/ValueCompareVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/ValueCompareVisibilityConverter.cs
@@ -16,5 +16,9 @@ public sealed class ValueCompareVisibilityConverter : IValueConverter
         ConversionHelpers.TryDecimal(value, culture, out var number) && number > 0;
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.IsTrue(value, culture) ? 1 : 0;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.IsTrue(value, culture) ? 1 : 0;
 }

--- a/src/XamlConverters.Avalonia/ValueGreaterThanXToBoolConverter.cs
+++ b/src/XamlConverters.Avalonia/ValueGreaterThanXToBoolConverter.cs
@@ -14,10 +14,16 @@ public sealed class ValueGreaterThanXToBoolConverter : IValueConverter
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        var threshold = ConversionHelpers.TryDecimal(parameter, culture, out var parsed) ? parsed : 0m;
+        var threshold = ConversionHelpers.TryDecimal(parameter, culture, out var parsed)
+            ? parsed
+            : 0M;
         return ConversionHelpers.TryDecimal(value, culture, out var number) && number > threshold;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ValueGtXConverter.cs
+++ b/src/XamlConverters.Avalonia/ValueGtXConverter.cs
@@ -16,10 +16,15 @@ public sealed class ValueGtXConverter : IValueConverter
 
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryDecimal(value, culture, out var number) && ConversionHelpers.TryDecimal(parameter, culture, out var threshold)
+        ConversionHelpers.TryDecimal(value, culture, out var number)
+        && ConversionHelpers.TryDecimal(parameter, culture, out var threshold)
             ? Math.Round(number, number > threshold ? 1 : DefaultPrecision)
             : ConversionHelpers.UnsetValue;
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ValueLessThanXToBoolConverter.cs
+++ b/src/XamlConverters.Avalonia/ValueLessThanXToBoolConverter.cs
@@ -14,10 +14,16 @@ public sealed class ValueLessThanXToBoolConverter : IValueConverter
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        var threshold = ConversionHelpers.TryDecimal(parameter, culture, out var parsed) ? parsed : 0m;
+        var threshold = ConversionHelpers.TryDecimal(parameter, culture, out var parsed)
+            ? parsed
+            : 0M;
         return ConversionHelpers.TryDecimal(value, culture, out var number) && number < threshold;
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ValueNotNullToBoolConverter.cs
+++ b/src/XamlConverters.Avalonia/ValueNotNullToBoolConverter.cs
@@ -19,12 +19,17 @@ public sealed class ValueNotNullToBoolConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 
     /// <summary>Determines whether the null check should be inverted.</summary>
     /// <param name="parameter">The converter parameter.</param>
     /// <returns><see langword="true"/> when inversion was requested; otherwise, <see langword="false"/>.</returns>
     private static bool IsInverted(object? parameter) =>
-        parameter is true || string.Equals(parameter?.ToString(), "reverse", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(parameter?.ToString(), "invert", StringComparison.OrdinalIgnoreCase);
+        parameter is true
+        || string.Equals(parameter?.ToString(), "reverse", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(parameter?.ToString(), "invert", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/XamlConverters.Avalonia/ValueNotNullToVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/ValueNotNullToVisibilityConverter.cs
@@ -15,7 +15,9 @@ public sealed class ValueNotNullToVisibilityConverter : IValueConverter
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var show = !ConversionHelpers.IsNullLike(value);
-        if (parameter is true || string.Equals(parameter?.ToString(), "reverse", StringComparison.OrdinalIgnoreCase))
+        if (
+            parameter is true
+            || string.Equals(parameter?.ToString(), "reverse", StringComparison.OrdinalIgnoreCase))
         {
             show = !show;
         }
@@ -24,5 +26,9 @@ public sealed class ValueNotNullToVisibilityConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ValueToBrushConverter.cs
+++ b/src/XamlConverters.Avalonia/ValueToBrushConverter.cs
@@ -15,7 +15,9 @@ public sealed class ValueToBrushConverter : IValueConverter
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        var active = value is bool boolean ? !boolean : ConversionHelpers.TryDecimal(value, culture, out var number) && number > 0;
+        var active = value is bool boolean
+            ? !boolean
+            : ConversionHelpers.TryDecimal(value, culture, out var number) && number > 0;
         var mode = parameter?.ToString() ?? string.Empty;
         if (mode.Contains("BackPressure", StringComparison.OrdinalIgnoreCase))
         {
@@ -31,5 +33,9 @@ public sealed class ValueToBrushConverter : IValueConverter
     }
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/VisibilityFromNumberConverter.cs
+++ b/src/XamlConverters.Avalonia/VisibilityFromNumberConverter.cs
@@ -13,8 +13,14 @@ public sealed class VisibilityFromNumberConverter : IValueConverter
 {
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryDecimal(value, culture, out var number) && ConversionHelpers.TryDecimal(parameter, culture, out var threshold) && number >= threshold;
+        ConversionHelpers.TryDecimal(value, culture, out var number)
+        && ConversionHelpers.TryDecimal(parameter, culture, out var threshold)
+        && number >= threshold;
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/VisibilityFromNumberEqualsConverter.cs
+++ b/src/XamlConverters.Avalonia/VisibilityFromNumberEqualsConverter.cs
@@ -13,8 +13,14 @@ public sealed class VisibilityFromNumberEqualsConverter : IValueConverter
 {
     /// <inheritdoc/>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        ConversionHelpers.TryDecimal(value, culture, out var number) && ConversionHelpers.TryDecimal(parameter, culture, out var threshold) && number == threshold;
+        ConversionHelpers.TryDecimal(value, culture, out var number)
+        && ConversionHelpers.TryDecimal(parameter, culture, out var threshold)
+        && number == threshold;
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Avalonia/ZeroToVisibilityConverter.cs
+++ b/src/XamlConverters.Avalonia/ZeroToVisibilityConverter.cs
@@ -16,5 +16,9 @@ public sealed class ZeroToVisibilityConverter : IValueConverter
         ConversionHelpers.TryDecimal(value, culture, out var number) && number == 0;
 
     /// <inheritdoc/>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConversionHelpers.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConversionHelpers.DoNothing;
 }

--- a/src/XamlConverters.Tests/ArithmeticConverterTests.cs
+++ b/src/XamlConverters.Tests/ArithmeticConverterTests.cs
@@ -15,14 +15,21 @@ public class ArithmeticConverterTests
     /// <param name="expected">The expected.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
-    [Arguments(10, "+5", 15d)]
-    [Arguments(10, "- 3", 7d)]
-    [Arguments(10, "*2", 20d)]
-    [Arguments(10, "/2", 5d)]
+    [Arguments(10, "+5", 15D)]
+    [Arguments(10, "- 3", 7D)]
+    [Arguments(10, "*2", 20D)]
+    [Arguments(10, "/2", 5D)]
     public async Task PerformsArithmetic(int input, string param, double expected)
     {
         var c = new ArithmeticConverter();
-        var result = ((IValueConverter)c).Convert(input, typeof(double), param, System.Globalization.CultureInfo.InvariantCulture);
-        await Assert.That((double)result).IsEqualTo(expected).Within(TestValues.FloatingPointTolerance);
+        var result = ((IValueConverter)c).Convert(
+            input,
+            typeof(double),
+            param,
+            System.Globalization.CultureInfo.InvariantCulture);
+        await Assert
+            .That((double)result)
+            .IsEqualTo(expected)
+            .Within(TestValues.FloatingPointTolerance);
     }
 }

--- a/src/XamlConverters.Tests/BclConverterTests.cs
+++ b/src/XamlConverters.Tests/BclConverterTests.cs
@@ -20,8 +20,12 @@ public class BclConverterTests
     {
         var converter = new ChangeTypeConverter();
 
-        await Assert.That(converter.Convert("42", typeof(int), null, InvariantCulture)).IsEqualTo(TestValues.Answer);
-        await Assert.That(converter.ConvertBack(TestValues.Answer, typeof(string), null, InvariantCulture)).IsEqualTo("42");
+        await Assert
+            .That(converter.Convert("42", typeof(int), null, InvariantCulture))
+            .IsEqualTo(TestValues.Answer);
+        await Assert
+            .That(converter.ConvertBack(TestValues.Answer, typeof(string), null, InvariantCulture))
+            .IsEqualTo("42");
     }
 
     /// <summary>Converts GUID text and byte-array representations.</summary>
@@ -45,8 +49,13 @@ public class BclConverterTests
     public async Task ConvertsBase64Representations()
     {
         var converter = new ByteArrayToBase64Converter();
-        var encoded = converter.Convert(new byte[] { 1, TestValues.SecondByte, TestValues.ThirdByte }, typeof(string), null, InvariantCulture);
-        var decoded = (byte[])converter.ConvertBack(encoded, typeof(byte[]), null, InvariantCulture);
+        var encoded = converter.Convert(
+            new byte[] { 1, TestValues.SecondByte, TestValues.ThirdByte },
+            typeof(string),
+            null,
+            InvariantCulture);
+        var decoded = (byte[])
+            converter.ConvertBack(encoded, typeof(byte[]), null, InvariantCulture);
 
         await Assert.That(encoded).IsEqualTo("AQID");
         await Assert.That(decoded.Length).IsEqualTo(TestValues.SampleValueCount);
@@ -58,12 +67,33 @@ public class BclConverterTests
     [Test]
     public async Task ConvertsCollectionValues()
     {
-        var values = new[] { TestValues.FirstSampleValue, TestValues.SecondSampleValue, TestValues.ThirdSampleValue };
+        var values = new[]
+        {
+            TestValues.FirstSampleValue,
+            TestValues.SecondSampleValue,
+            TestValues.ThirdSampleValue,
+        };
 
-        var contains = new CollectionContainsConverter().Convert(values, typeof(bool), "20", InvariantCulture);
-        var item = new CollectionItemConverter().Convert(values, typeof(int), "1", InvariantCulture);
-        var first = new CollectionFirstOrDefaultConverter().Convert(Array.Empty<int>(), typeof(int), TestValues.MissingSampleValue, InvariantCulture);
-        var joined = new EnumerableToStringConverter().Convert(values, typeof(string), "|", InvariantCulture);
+        var contains = new CollectionContainsConverter().Convert(
+            values,
+            typeof(bool),
+            "20",
+            InvariantCulture);
+        var item = new CollectionItemConverter().Convert(
+            values,
+            typeof(int),
+            "1",
+            InvariantCulture);
+        var first = new CollectionFirstOrDefaultConverter().Convert(
+            Array.Empty<int>(),
+            typeof(int),
+            TestValues.MissingSampleValue,
+            InvariantCulture);
+        var joined = new EnumerableToStringConverter().Convert(
+            values,
+            typeof(string),
+            "|",
+            InvariantCulture);
 
         await Assert.That((bool)contains).IsTrue();
         await Assert.That(item).IsEqualTo(TestValues.SecondSampleValue);
@@ -81,9 +111,18 @@ public class BclConverterTests
         var values = new EnumValuesConverter();
 
         var text = description.Convert(SampleFlags.Read, typeof(string), null, InvariantCulture);
-        var restored = description.ConvertBack("Can read", typeof(SampleFlags), null, InvariantCulture);
-        var hasFlag = flag.Convert(SampleFlags.Read | SampleFlags.Write, typeof(bool), "Write", InvariantCulture);
-        var enumValues = (Array)values.Convert(typeof(SampleFlags), typeof(IEnumerable), null, InvariantCulture);
+        var restored = description.ConvertBack(
+            "Can read",
+            typeof(SampleFlags),
+            null,
+            InvariantCulture);
+        var hasFlag = flag.Convert(
+            SampleFlags.Read | SampleFlags.Write,
+            typeof(bool),
+            "Write",
+            InvariantCulture);
+        var enumValues = (Array)
+            values.Convert(typeof(SampleFlags), typeof(IEnumerable), null, InvariantCulture);
 
         await Assert.That(text).IsEqualTo("Can read");
         await Assert.That(restored).IsEqualTo(SampleFlags.Read);

--- a/src/XamlConverters.Tests/CommonConverterTests.cs
+++ b/src/XamlConverters.Tests/CommonConverterTests.cs
@@ -18,8 +18,16 @@ public class CommonConverterTests
     [Test]
     public async Task ConvertsTextCasing()
     {
-        var upper = new ToUpperConverter().Convert("Mixed Case", typeof(string), null!, InvariantCulture);
-        var lower = new ToLowerConverter().Convert("Mixed Case", typeof(string), null!, InvariantCulture);
+        var upper = new ToUpperConverter().Convert(
+            "Mixed Case",
+            typeof(string),
+            null!,
+            InvariantCulture);
+        var lower = new ToLowerConverter().Convert(
+            "Mixed Case",
+            typeof(string),
+            null!,
+            InvariantCulture);
 
         await Assert.That(upper).IsEqualTo("MIXED CASE");
         await Assert.That(lower).IsEqualTo("mixed case");
@@ -36,8 +44,12 @@ public class CommonConverterTests
     {
         var converter = new BoolNegationConverter();
 
-        await Assert.That((bool)converter.Convert(input, typeof(bool), null!, InvariantCulture)).IsEqualTo(expected);
-        await Assert.That((bool)converter.ConvertBack(input, typeof(bool), null!, InvariantCulture)).IsEqualTo(expected);
+        await Assert
+            .That((bool)converter.Convert(input, typeof(bool), null!, InvariantCulture))
+            .IsEqualTo(expected);
+        await Assert
+            .That((bool)converter.ConvertBack(input, typeof(bool), null!, InvariantCulture))
+            .IsEqualTo(expected);
     }
 
     /// <summary>Compares values with optional inversion.</summary>
@@ -48,10 +60,18 @@ public class CommonConverterTests
         var equality = new EqualityConverter();
         var objectEquality = new ObjectEqualsParameterConverter();
 
-        await Assert.That((bool)equality.Convert(TestValues.Answer, typeof(bool), "42", InvariantCulture)).IsTrue();
-        await Assert.That((bool)equality.Convert(TestValues.Answer, typeof(bool), "!42", InvariantCulture)).IsFalse();
-        await Assert.That((bool)objectEquality.Convert("VALUE", typeof(bool), "value", InvariantCulture)).IsTrue();
-        await Assert.That((bool)objectEquality.Convert("VALUE", typeof(bool), "!value", InvariantCulture)).IsFalse();
+        await Assert
+            .That((bool)equality.Convert(TestValues.Answer, typeof(bool), "42", InvariantCulture))
+            .IsTrue();
+        await Assert
+            .That((bool)equality.Convert(TestValues.Answer, typeof(bool), "!42", InvariantCulture))
+            .IsFalse();
+        await Assert
+            .That((bool)objectEquality.Convert("VALUE", typeof(bool), "value", InvariantCulture))
+            .IsTrue();
+        await Assert
+            .That((bool)objectEquality.Convert("VALUE", typeof(bool), "!value", InvariantCulture))
+            .IsFalse();
     }
 
     /// <summary>Reports simple and fully-qualified type names.</summary>
@@ -61,8 +81,12 @@ public class CommonConverterTests
     {
         var converter = new ObjectToTypeNameConverter();
 
-        await Assert.That(converter.Convert(TestValues.Answer, typeof(string), null!, InvariantCulture)).IsEqualTo("Int32");
-        await Assert.That(converter.Convert(TestValues.Answer, typeof(string), "full", InvariantCulture)).IsEqualTo("System.Int32");
+        await Assert
+            .That(converter.Convert(TestValues.Answer, typeof(string), null!, InvariantCulture))
+            .IsEqualTo("Int32");
+        await Assert
+            .That(converter.Convert(TestValues.Answer, typeof(string), "full", InvariantCulture))
+            .IsEqualTo("System.Int32");
     }
 
     /// <summary>Multiplies and divides numeric values symmetrically.</summary>
@@ -71,11 +95,25 @@ public class CommonConverterTests
     public async Task MultipliesAndDividesNumericValues()
     {
         var converter = new MultiplierConverter();
-        var converted = converter.Convert(TestValues.MultiplierInput, typeof(double), "2.5", InvariantCulture);
-        var convertedBack = converter.ConvertBack(converted, typeof(double), "2.5", InvariantCulture);
+        var converted = converter.Convert(
+            TestValues.MultiplierInput,
+            typeof(double),
+            "2.5",
+            InvariantCulture);
+        var convertedBack = converter.ConvertBack(
+            converted,
+            typeof(double),
+            "2.5",
+            InvariantCulture);
 
-        await Assert.That((double)converted).IsEqualTo(TestValues.MultipliedValue).Within(TestValues.FloatingPointTolerance);
-        await Assert.That((double)convertedBack).IsEqualTo(TestValues.MultiplierInput).Within(TestValues.FloatingPointTolerance);
+        await Assert
+            .That((double)converted)
+            .IsEqualTo(TestValues.MultipliedValue)
+            .Within(TestValues.FloatingPointTolerance);
+        await Assert
+            .That((double)convertedBack)
+            .IsEqualTo(TestValues.MultiplierInput)
+            .Within(TestValues.FloatingPointTolerance);
     }
 
     /// <summary>Supports both value/parameter and multi-value comparisons.</summary>
@@ -84,8 +122,16 @@ public class CommonConverterTests
     public async Task ComparesGreaterThanOrEqualValues()
     {
         var converter = new IsGreaterThanOrEqualToConverter();
-        var singleResult = ((IValueConverter)converter).Convert(TestValues.ComparisonBoundary, typeof(bool), TestValues.ComparisonBoundary, InvariantCulture);
-        var multiResult = ((IMultiValueConverter)converter).Convert([TestValues.BelowComparisonBoundary, TestValues.ComparisonBoundary], typeof(bool), null!, InvariantCulture);
+        var singleResult = ((IValueConverter)converter).Convert(
+            TestValues.ComparisonBoundary,
+            typeof(bool),
+            TestValues.ComparisonBoundary,
+            InvariantCulture);
+        var multiResult = ((IMultiValueConverter)converter).Convert(
+            [TestValues.BelowComparisonBoundary, TestValues.ComparisonBoundary],
+            typeof(bool),
+            null!,
+            InvariantCulture);
 
         await Assert.That((bool)singleResult).IsTrue();
         await Assert.That((bool)multiResult).IsFalse();

--- a/src/XamlConverters.Tests/CountConvertersTests.cs
+++ b/src/XamlConverters.Tests/CountConvertersTests.cs
@@ -13,7 +13,11 @@ public class CountConvertersTests
     public async Task CountToBoolean_GreaterThanZero()
     {
         var c = new CountToBooleanConverter();
-        var result = c.Convert(new List<int> { 1, TestValues.SecondByte }, typeof(bool), ">0", System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            new List<int> { 1, TestValues.SecondByte },
+            typeof(bool),
+            ">0",
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That((bool)result).IsTrue();
     }
 
@@ -23,7 +27,11 @@ public class CountConvertersTests
     public async Task CountToVisibility_EqualsZeroCollapsed()
     {
         var c = new CountToVisibilityConverter();
-        var result = c.Convert(Enumerable.Empty<int>(), typeof(Visibility), "==0", System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            Enumerable.Empty<int>(),
+            typeof(Visibility),
+            "==0",
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That(result).IsEqualTo(Visibility.Visible); // Visible because ==0 satisfied
     }
 }

--- a/src/XamlConverters.Tests/MathConverterTests.cs
+++ b/src/XamlConverters.Tests/MathConverterTests.cs
@@ -13,7 +13,14 @@ public class MathConverterTests
     public async Task EvaluatesExpression()
     {
         var c = new MathConverter();
-        var result = c.Convert([TestValues.MathLeftOperand, TestValues.MathRightOperand], typeof(double), "{0}+{1}*2", System.Globalization.CultureInfo.InvariantCulture);
-        await Assert.That((double)result).IsEqualTo(TestValues.MathExpectedResult).Within(TestValues.FloatingPointTolerance);
+        var result = c.Convert(
+            [TestValues.MathLeftOperand, TestValues.MathRightOperand],
+            typeof(double),
+            "{0}+{1}*2",
+            System.Globalization.CultureInfo.InvariantCulture);
+        await Assert
+            .That((double)result)
+            .IsEqualTo(TestValues.MathExpectedResult)
+            .Within(TestValues.FloatingPointTolerance);
     }
 }

--- a/src/XamlConverters.Tests/MultiBooleanConvertersTests.cs
+++ b/src/XamlConverters.Tests/MultiBooleanConvertersTests.cs
@@ -13,7 +13,11 @@ public class MultiBooleanConvertersTests
     public async Task And_AllTrue_ReturnsTrue()
     {
         var c = new MultiBooleanAndConverter();
-        var result = c.Convert([true, true, true], typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            [true, true, true],
+            typeof(bool),
+            null!,
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That((bool)result).IsTrue();
     }
 
@@ -23,7 +27,11 @@ public class MultiBooleanConvertersTests
     public async Task And_OneFalse_ReturnsFalse()
     {
         var c = new MultiBooleanAndConverter();
-        var result = c.Convert([true, false, true], typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            [true, false, true],
+            typeof(bool),
+            null!,
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That((bool)result).IsFalse();
     }
 
@@ -33,7 +41,11 @@ public class MultiBooleanConvertersTests
     public async Task Or_AnyTrue_ReturnsTrue()
     {
         var c = new MultiBooleanOrConverter();
-        var result = c.Convert([false, false, true], typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            [false, false, true],
+            typeof(bool),
+            null!,
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That((bool)result).IsTrue();
     }
 
@@ -43,7 +55,11 @@ public class MultiBooleanConvertersTests
     public async Task Or_AllFalse_ReturnsFalse()
     {
         var c = new MultiBooleanOrConverter();
-        var result = c.Convert([false, false], typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            [false, false],
+            typeof(bool),
+            null!,
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That((bool)result).IsFalse();
     }
 
@@ -53,7 +69,11 @@ public class MultiBooleanConvertersTests
     public async Task Xor_OddTrue_ReturnsTrue()
     {
         var c = new BooleanXorConverter();
-        var result = c.Convert([true, false, true], typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            [true, false, true],
+            typeof(bool),
+            null!,
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That((bool)result).IsFalse(); // two trues -> even -> false
     }
 
@@ -63,7 +83,11 @@ public class MultiBooleanConvertersTests
     public async Task Xor_SingleTrue_ReturnsTrue()
     {
         var c = new BooleanXorConverter();
-        var result = c.Convert([true, false, false], typeof(bool), null!, System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            [true, false, false],
+            typeof(bool),
+            null!,
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That((bool)result).IsTrue();
     }
 }

--- a/src/XamlConverters.Tests/NullCoalesceConverterTests.cs
+++ b/src/XamlConverters.Tests/NullCoalesceConverterTests.cs
@@ -16,7 +16,11 @@ public class NullCoalesceConverterTests
     public async Task ReturnsParameterIfNull()
     {
         var c = new NullCoalesceConverter();
-        var result = c.Convert(null!, typeof(string), FallbackValue, System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            null!,
+            typeof(string),
+            FallbackValue,
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That(result).IsEqualTo(FallbackValue);
     }
 
@@ -26,7 +30,11 @@ public class NullCoalesceConverterTests
     public async Task ReturnsValueIfNotNull()
     {
         var c = new NullCoalesceConverter();
-        var result = c.Convert("value", typeof(string), FallbackValue, System.Globalization.CultureInfo.InvariantCulture);
+        var result = c.Convert(
+            "value",
+            typeof(string),
+            FallbackValue,
+            System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That(result).IsEqualTo("value");
     }
 }

--- a/src/XamlConverters.Tests/PercentageConverterTests.cs
+++ b/src/XamlConverters.Tests/PercentageConverterTests.cs
@@ -13,8 +13,8 @@ public class PercentageConverterTests
     /// <param name="expected">The expected.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
-    [Arguments(200d, "50%", 100d)]
-    [Arguments(10d, "0.5", 5d)]
+    [Arguments(200D, "50%", 100D)]
+    [Arguments(10D, "0.5", 5D)]
     public async Task AppliesPercentage(double input, string param, double expected)
     {
         var c = new PercentageConverter();

--- a/src/XamlConverters.Tests/TestValues.cs
+++ b/src/XamlConverters.Tests/TestValues.cs
@@ -38,13 +38,13 @@ internal static class TestValues
     public const int MissingSampleValue = 99;
 
     /// <summary>The tolerance used for floating-point assertions.</summary>
-    public const double FloatingPointTolerance = 0.00001d;
+    public const double FloatingPointTolerance = 0.00001D;
 
     /// <summary>The input used by multiplier tests.</summary>
     public const int MultiplierInput = 6;
 
     /// <summary>The expected multiplied value.</summary>
-    public const double MultipliedValue = 15d;
+    public const double MultipliedValue = 15D;
 
     /// <summary>The comparison boundary used by comparison tests.</summary>
     public const int ComparisonBoundary = 5;
@@ -59,7 +59,7 @@ internal static class TestValues
     public const int MathRightOperand = 3;
 
     /// <summary>The expected math-expression result.</summary>
-    public const double MathExpectedResult = 11d;
+    public const double MathExpectedResult = 11D;
 
     /// <summary>The uniform thickness used by the all-sides test.</summary>
     public const int UniformThickness = 5;

--- a/src/XamlConverters.Tests/ThicknessUniformConverterTests.cs
+++ b/src/XamlConverters.Tests/ThicknessUniformConverterTests.cs
@@ -13,7 +13,12 @@ public class ThicknessUniformConverterTests
     public async Task AllSides()
     {
         var c = new ThicknessUniformConverter();
-        var t = (Thickness)c.Convert(TestValues.UniformThickness, typeof(Thickness), null!, System.Globalization.CultureInfo.InvariantCulture);
+        var t = (Thickness)
+            c.Convert(
+                TestValues.UniformThickness,
+                typeof(Thickness),
+                null!,
+                System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That(t).IsEqualTo(new Thickness(TestValues.UniformThickness));
     }
 
@@ -23,10 +28,15 @@ public class ThicknessUniformConverterTests
     public async Task HorizontalOnly()
     {
         var c = new ThicknessUniformConverter();
-        var t = (Thickness)c.Convert(TestValues.HorizontalThickness, typeof(Thickness), "H", System.Globalization.CultureInfo.InvariantCulture);
+        var t = (Thickness)
+            c.Convert(
+                TestValues.HorizontalThickness,
+                typeof(Thickness),
+                "H",
+                System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That(t.Left).IsEqualTo(TestValues.HorizontalThickness);
         await Assert.That(t.Right).IsEqualTo(TestValues.HorizontalThickness);
-        await Assert.That(t.Top).IsEqualTo(0d);
-        await Assert.That(t.Bottom).IsEqualTo(0d);
+        await Assert.That(t.Top).IsEqualTo(0D);
+        await Assert.That(t.Bottom).IsEqualTo(0D);
     }
 }

--- a/src/XamlConverters.Tests/VisibilityConverterTests.cs
+++ b/src/XamlConverters.Tests/VisibilityConverterTests.cs
@@ -19,9 +19,22 @@ public class VisibilityConverterTests
     {
         var converter = new InvertVisibilityConverter();
 
-        await Assert.That(converter.Convert(Visibility.Visible, typeof(Visibility), null!, InvariantCulture)).IsEqualTo(Visibility.Collapsed);
-        await Assert.That(converter.Convert(Visibility.Visible, typeof(Visibility), "hidden", InvariantCulture)).IsEqualTo(Visibility.Hidden);
-        await Assert.That(converter.Convert(Visibility.Collapsed, typeof(Visibility), null!, InvariantCulture)).IsEqualTo(Visibility.Visible);
+        await Assert
+            .That(
+                converter.Convert(Visibility.Visible, typeof(Visibility), null!, InvariantCulture))
+            .IsEqualTo(Visibility.Collapsed);
+        await Assert
+            .That(
+                converter.Convert(
+                    Visibility.Visible,
+                    typeof(Visibility),
+                    "hidden",
+                    InvariantCulture))
+            .IsEqualTo(Visibility.Hidden);
+        await Assert
+            .That(
+                converter.Convert(Visibility.Collapsed, typeof(Visibility), null!, InvariantCulture))
+            .IsEqualTo(Visibility.Visible);
     }
 
     /// <summary>Maps empty and populated strings to visibility values.</summary>
@@ -31,10 +44,18 @@ public class VisibilityConverterTests
     {
         var converter = new StringNullOrEmptyToVisibilityConverter();
 
-        await Assert.That(converter.Convert(string.Empty, typeof(Visibility), null!, InvariantCulture)).IsEqualTo(Visibility.Collapsed);
-        await Assert.That(converter.Convert("value", typeof(Visibility), null!, InvariantCulture)).IsEqualTo(Visibility.Visible);
-        await Assert.That(converter.Convert(string.Empty, typeof(Visibility), "hidden", InvariantCulture)).IsEqualTo(Visibility.Hidden);
-        await Assert.That(converter.Convert(string.Empty, typeof(Visibility), "invert", InvariantCulture)).IsEqualTo(Visibility.Visible);
+        await Assert
+            .That(converter.Convert(string.Empty, typeof(Visibility), null!, InvariantCulture))
+            .IsEqualTo(Visibility.Collapsed);
+        await Assert
+            .That(converter.Convert("value", typeof(Visibility), null!, InvariantCulture))
+            .IsEqualTo(Visibility.Visible);
+        await Assert
+            .That(converter.Convert(string.Empty, typeof(Visibility), "hidden", InvariantCulture))
+            .IsEqualTo(Visibility.Hidden);
+        await Assert
+            .That(converter.Convert(string.Empty, typeof(Visibility), "invert", InvariantCulture))
+            .IsEqualTo(Visibility.Visible);
     }
 
     /// <summary>Maps zero and non-zero values to visibility.</summary>
@@ -47,7 +68,11 @@ public class VisibilityConverterTests
     [Arguments(-1, Visibility.Collapsed)]
     public async Task ConvertsZeroToVisibility(int input, Visibility expected)
     {
-        var result = new ZeroToVisibilityConverter().Convert(input, typeof(Visibility), null!, InvariantCulture);
+        var result = new ZeroToVisibilityConverter().Convert(
+            input,
+            typeof(Visibility),
+            null!,
+            InvariantCulture);
 
         await Assert.That(result).IsEqualTo(expected);
     }
@@ -59,8 +84,14 @@ public class VisibilityConverterTests
     {
         var converter = new ValueNotNullToVisibilityConverter();
 
-        await Assert.That(converter.Convert(new object(), typeof(Visibility), null!, InvariantCulture)).IsEqualTo(Visibility.Visible);
-        await Assert.That(converter.Convert(null!, typeof(Visibility), null!, InvariantCulture)).IsEqualTo(Visibility.Collapsed);
-        await Assert.That(converter.Convert(null!, typeof(Visibility), "reverse", InvariantCulture)).IsEqualTo(Visibility.Visible);
+        await Assert
+            .That(converter.Convert(new object(), typeof(Visibility), null!, InvariantCulture))
+            .IsEqualTo(Visibility.Visible);
+        await Assert
+            .That(converter.Convert(null!, typeof(Visibility), null!, InvariantCulture))
+            .IsEqualTo(Visibility.Collapsed);
+        await Assert
+            .That(converter.Convert(null!, typeof(Visibility), "reverse", InvariantCulture))
+            .IsEqualTo(Visibility.Visible);
     }
 }

--- a/src/XamlConverters/ArithmeticConverter.cs
+++ b/src/XamlConverters/ArithmeticConverter.cs
@@ -25,7 +25,9 @@ public class ArithmeticConverter : IValueConverter
     private const string ArithmeticParseExpression = "([+\\-*/]{1,1})\\s{0,}(\\-?[\\d\\.]+)";
 
     /// <summary>Compiled arithmetic expression.</summary>
-    private static readonly Regex ArithmeticRegex = new(ArithmeticParseExpression, RegexOptions.Compiled);
+    private static readonly Regex ArithmeticRegex = new(
+        ArithmeticParseExpression,
+        RegexOptions.Compiled);
 #endif
 
     /// <summary>Carries out arithmetic on the value based on the parameter.</summary>
@@ -34,7 +36,11 @@ public class ArithmeticConverter : IValueConverter
     /// <param name="parameter">A math operator (+,-,*,/) plus a value.</param>
     /// <param name="culture">Not used.</param>
     /// <returns>Integer or Double based on Math.</returns>
-    object IValueConverter.Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    object IValueConverter.Convert(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture)
     {
         var parameterText = parameter?.ToString();
         if (string.IsNullOrEmpty(parameterText))
@@ -52,8 +58,14 @@ public class ArithmeticConverter : IValueConverter
         var numericValue = match.Groups[OperandGroupIndex].Value;
         return value switch
         {
-            double doubleValue when double.TryParse(numericValue, out var operand) => Apply(doubleValue, operand, operation),
-            int integerValue when int.TryParse(numericValue, out var operand) => Apply(integerValue, operand, operation),
+            double doubleValue when double.TryParse(numericValue, out var operand) => Apply(
+                doubleValue,
+                operand,
+                operation),
+            int integerValue when int.TryParse(numericValue, out var operand) => Apply(
+                integerValue,
+                operand,
+                operation),
             _ => CreateConversionError(),
         };
     }
@@ -64,38 +76,46 @@ public class ArithmeticConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The conversion culture.</param>
     /// <returns>The WPF do-nothing binding sentinel.</returns>
-    object IValueConverter.ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    object IValueConverter.ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 
     /// <summary>Applies an arithmetic operation to double values.</summary>
     /// <param name="value">The left operand.</param>
     /// <param name="operand">The right operand.</param>
     /// <param name="operation">The operation to apply.</param>
     /// <returns>The operation result.</returns>
-    private static double Apply(double value, double operand, string operation) => operation switch
-    {
-        "+" => value + operand,
-        "-" => value - operand,
-        "*" => value * operand,
-        "/" => value / operand,
-        _ => 0d,
-    };
+    private static double Apply(double value, double operand, string operation) =>
+        operation switch
+        {
+            "+" => value + operand,
+            "-" => value - operand,
+            "*" => value * operand,
+            "/" => value / operand,
+            _ => 0D,
+        };
 
     /// <summary>Applies an arithmetic operation to integer values.</summary>
     /// <param name="value">The left operand.</param>
     /// <param name="operand">The right operand.</param>
     /// <param name="operation">The operation to apply.</param>
     /// <returns>The operation result.</returns>
-    private static double Apply(int value, int operand, string operation) => operation switch
-    {
-        "+" => value + operand,
-        "-" => value - operand,
-        "*" => value * operand,
-        "/" => (double)value / operand,
-        _ => 0d,
-    };
+    private static double Apply(int value, int operand, string operation) =>
+        operation switch
+        {
+            "+" => value + operand,
+            "-" => value - operand,
+            "*" => value * operand,
+            "/" => (double)value / operand,
+            _ => 0D,
+        };
 
     /// <summary>Creates the converter's invalid-input result.</summary>
     /// <returns>An exception describing the invalid input.</returns>
     private static InvalidCastException CreateConversionError() =>
-        new("Binding must be an integer or double, and the parameter must contain an arithmetic operator (+, -, *, or /) followed by a value.");
+        new(
+            "Binding must be an integer or double, and the parameter must contain "
+                + "an arithmetic operator (+, -, *, or /) followed by a value.");
 }

--- a/src/XamlConverters/BackgroundColorToBwForegroundConverter.cs
+++ b/src/XamlConverters/BackgroundColorToBwForegroundConverter.cs
@@ -42,8 +42,14 @@ public class BackgroundColorToBwForegroundConverter : IValueConverter
         }
 
         var colorValue = uint.Parse(text, NumberStyles.HexNumber);
-        var grayScale = (((colorValue & 0xff0000) >> 16) + ((colorValue & 0x00ff00) >> 8) + (colorValue & 0x0000ff)) / ColorChannelCount;
-        return grayScale <= ContrastThreshold ? new SolidColorBrush(Colors.White) : new SolidColorBrush(Colors.Black);
+        var grayScale =
+            (
+                ((colorValue & 0xff0000) >> 16)
+                + ((colorValue & 0x00ff00) >> 8)
+                + (colorValue & 0x0000ff)) / ColorChannelCount;
+        return grayScale <= ContrastThreshold
+            ? new SolidColorBrush(Colors.White)
+            : new SolidColorBrush(Colors.Black);
     }
 
     /// <summary>Returns the WPF do-nothing binding sentinel because reverse conversion is unsupported.</summary>
@@ -52,5 +58,9 @@ public class BackgroundColorToBwForegroundConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>The WPF do-nothing binding sentinel.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Boolean/BoolNegationConverter.cs
+++ b/src/XamlConverters/Boolean/BoolNegationConverter.cs
@@ -16,7 +16,8 @@ public sealed class BoolNegationConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => !(value is bool x && x);
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        !(value is bool x && x);
 
     /// <summary>Converts a value.</summary>
     /// <param name="value">The value that is produced by the binding target.</param>
@@ -24,5 +25,9 @@ public sealed class BoolNegationConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => !(value is bool x && x);
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => !(value is bool x && x);
 }

--- a/src/XamlConverters/Boolean/BoolToOpacityConverter.cs
+++ b/src/XamlConverters/Boolean/BoolToOpacityConverter.cs
@@ -12,7 +12,7 @@ namespace CP.Xaml.Converters;
 public class BoolToOpacityConverter : IValueConverter
 {
     /// <summary>The opacity representing a fully visible element.</summary>
-    private const double FullyOpaque = 1d;
+    private const double FullyOpaque = 1D;
 
     /// <summary>The integral opacity representing a fully visible element.</summary>
     private const int FullyOpaqueInteger = 1;
@@ -21,7 +21,7 @@ public class BoolToOpacityConverter : IValueConverter
     private const double DoubleTolerance = 1e-9;
 
     /// <summary>The tolerance used when comparing single-precision opacity values.</summary>
-    private const float FloatTolerance = 1e-6f;
+    private const float FloatTolerance = 1e-6F;
 
     /// <summary>Converts the specified value.</summary>
     /// <param name="value">The value.</param>

--- a/src/XamlConverters/Boolean/BoolToStringTickCrossConverter.cs
+++ b/src/XamlConverters/Boolean/BoolToStringTickCrossConverter.cs
@@ -18,7 +18,9 @@ public class BoolToStringTickCrossConverter : IValueConverter
     /// <returns>Boolean to string Tick or Cross.</returns>
     /// <exception cref="InvalidCastException">The bound value is not Boolean.</exception>
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
-        value is bool x ? (object)(x ? "P" : "O") : throw new InvalidCastException("The binding value is not Boolean.");
+        value is bool x
+            ? (object)(x ? "P" : "O")
+            : throw new InvalidCastException("The binding value is not Boolean.");
 
     /// <summary>Converts the back.</summary>
     /// <param name="value">The value.</param>
@@ -27,6 +29,12 @@ public class BoolToStringTickCrossConverter : IValueConverter
     /// <param name="culture">The culture.</param>
     /// <returns>Convert Back.</returns>
     /// <exception cref="InvalidCastException">The bound value is not a string.</exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-        value is string text ? (object)(text == "P") : throw new InvalidCastException("The bound value is not a string.");
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) =>
+        value is string text
+            ? (object)(text == "P")
+            : throw new InvalidCastException("The bound value is not a string.");
 }

--- a/src/XamlConverters/Boolean/BooleanToValueConverter.cs
+++ b/src/XamlConverters/Boolean/BooleanToValueConverter.cs
@@ -47,7 +47,10 @@ public sealed class BooleanToValueConverter : IValueConverter
         }
 
         var selectedValue = condition ? TrueValue : FalseValue;
-        if (targetType == typeof(object) || selectedValue is null || targetType.IsInstanceOfType(selectedValue))
+        if (
+            targetType == typeof(object)
+            || selectedValue is null
+            || targetType.IsInstanceOfType(selectedValue))
         {
             return selectedValue;
         }
@@ -57,13 +60,18 @@ public sealed class BooleanToValueConverter : IValueConverter
             : Binding.DoNothing;
     }
 
-    /// <summary>Maps a target value back to a Boolean by comparing it with <see cref="TrueValue"/> and <see cref="FalseValue"/>.</summary>
+    /// <summary>Maps a target value back to a Boolean using the configured true and false values.</summary>
     /// <param name="value">The target value.</param>
     /// <param name="targetType">The binding source type.</param>
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
-    /// <returns>The corresponding Boolean, or <see cref="Binding.DoNothing"/> when no configured value matches.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    /// <returns>The corresponding Boolean, or <see cref="Binding.DoNothing"/> when no configured value matches.
+    /// </returns>
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         bool? result = null;
         if (ValuesEqual(value, TrueValue))
@@ -89,7 +97,8 @@ public sealed class BooleanToValueConverter : IValueConverter
     /// <returns><see langword="true"/> when the values are equivalent; otherwise, <see langword="false"/>.</returns>
     private static bool ValuesEqual(object? left, object? right) =>
         Equals(left, right)
-        || (left is not null
+        || (
+            left is not null
             && right is not null
             && string.Equals(left.ToString(), right.ToString(), StringComparison.Ordinal));
 }

--- a/src/XamlConverters/Boolean/BooleanXorConverter.cs
+++ b/src/XamlConverters/Boolean/BooleanXorConverter.cs
@@ -15,14 +15,24 @@ public sealed class BooleanXorConverter : IMultiValueConverter
     private const int ParityDivisor = 2;
 
     /// <summary>
-    /// Converts source values to a value for the binding target. The data binding engine calls this method when it propagates the values from source bindings to the binding target.
+    /// Converts source values to a value for the binding target. The data binding engine calls this method when it
+    /// propagates the values from source bindings to the binding target.
     /// </summary>
-    /// <param name="values">The array of values that the source bindings in the <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to provide for conversion.</param>
+    /// <param name="values">The array of values that the source bindings in the
+    /// <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value
+    /// <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to
+    /// provide for conversion.</param>
     /// <param name="targetType">The type of the binding target property.</param>
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>
-    /// A converted value.If the method returns null, the valid null value is used.A return value of <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the converter did not produce a value, and that the binding will use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default value.A return value of <see cref="T:System.Windows.Data.Binding" />.<see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
+    /// A converted value.If the method returns null, the valid null value is used.A return value of
+    /// <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" />
+    /// indicates that the converter did not produce a value, and that the binding will use the
+    /// <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default
+    /// value.A return value of <see cref="T:System.Windows.Data.Binding" />.
+    /// <see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or
+    /// use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
     /// </returns>
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
@@ -50,11 +60,16 @@ public sealed class BooleanXorConverter : IMultiValueConverter
 
     /// <summary>Converts a binding target value to the source binding values.</summary>
     /// <param name="value">The value that the binding target produces.</param>
-    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of values that are suggested for the method to return.</param>
+    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of
+    /// values that are suggested for the method to return.</param>
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>
     /// An array of values that have been converted from the target value back to the source values.
     /// </returns>
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => targetTypes.Select(_ => Binding.DoNothing).ToArray();
+    public object[] ConvertBack(
+        object value,
+        Type[] targetTypes,
+        object parameter,
+        CultureInfo culture) => targetTypes.Select(_ => Binding.DoNothing).ToArray();
 }

--- a/src/XamlConverters/Boolean/CollectionSizeToBoolConverter.cs
+++ b/src/XamlConverters/Boolean/CollectionSizeToBoolConverter.cs
@@ -17,7 +17,11 @@ public class CollectionSizeToBoolConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public virtual object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+    public virtual object Convert(
+        object value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         var reverse = parameter?.Equals("reverse");
         var requiredCollectionSize = 0;
@@ -65,5 +69,9 @@ public class CollectionSizeToBoolConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public virtual object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public virtual object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Boolean/EnumToBooleanConverter.cs
+++ b/src/XamlConverters/Boolean/EnumToBooleanConverter.cs
@@ -7,7 +7,7 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Converts between an Enum value and a boolean for e.g. RadioButton binding. Parameter must be the Enum member name.</summary>
+/// <summary>Converts between an enum value and a Boolean using the member name parameter.</summary>
 public sealed class EnumToBooleanConverter : IValueConverter
 {
     /// <summary>Converts a value.</summary>
@@ -20,7 +20,12 @@ public sealed class EnumToBooleanConverter : IValueConverter
     /// </returns>
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        return value is null || parameter is null ? false : string.Equals(value.ToString(), parameter.ToString(), StringComparison.OrdinalIgnoreCase);
+        return value is null || parameter is null
+            ? false
+            : string.Equals(
+                value.ToString(),
+                parameter.ToString(),
+                StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>Converts a value.</summary>
@@ -38,6 +43,8 @@ public sealed class EnumToBooleanConverter : IValueConverter
             return Binding.DoNothing;
         }
 
-        return value is bool b && b ? Enum.Parse(targetType, parameter.ToString()!, ignoreCase: true) : Binding.DoNothing;
+        return value is bool b && b
+            ? Enum.Parse(targetType, parameter.ToString()!, ignoreCase: true)
+            : Binding.DoNothing;
     }
 }

--- a/src/XamlConverters/Boolean/MultiBooleanAndConverter.cs
+++ b/src/XamlConverters/Boolean/MultiBooleanAndConverter.cs
@@ -8,7 +8,7 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Multi-binding converter that returns true only if ALL inputs are true. Parameter "invert" to invert final result.</summary>
+/// <summary>Returns true only when all inputs are true; use the "invert" parameter to invert the result.</summary>
 public sealed class MultiBooleanAndConverter : IMultiValueConverter
 {
     /// <summary>Aggregates values using logical AND.</summary>
@@ -47,17 +47,23 @@ public sealed class MultiBooleanAndConverter : IMultiValueConverter
             }
         }
 
-        var invert = parameter?.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true;
+        var invert =
+            parameter?.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true;
         return invert ? !result : result;
     }
 
     /// <summary>Convert back not supported.</summary>
     /// <param name="value">Ignored.</param>
-    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of values that are suggested for the method to return.</param>
+    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of
+    /// values that are suggested for the method to return.</param>
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>
     /// Array of DoNothing.
     /// </returns>
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => targetTypes.Select(t => Binding.DoNothing).ToArray();
+    public object[] ConvertBack(
+        object value,
+        Type[] targetTypes,
+        object parameter,
+        CultureInfo culture) => targetTypes.Select(t => Binding.DoNothing).ToArray();
 }

--- a/src/XamlConverters/Boolean/MultiBooleanOrConverter.cs
+++ b/src/XamlConverters/Boolean/MultiBooleanOrConverter.cs
@@ -8,16 +8,25 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Multi-binding converter that returns true if ANY input is true. Parameter "invert" to invert final result.</summary>
+/// <summary>Returns true when any input is true; use the "invert" parameter to invert the result.</summary>
 public sealed class MultiBooleanOrConverter : IMultiValueConverter
 {
     /// <summary>Aggregates values using logical OR.</summary>
-    /// <param name="values">The array of values that the source bindings in the <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to provide for conversion.</param>
+    /// <param name="values">The array of values that the source bindings in the
+    /// <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value
+    /// <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to
+    /// provide for conversion.</param>
     /// <param name="targetType">The type of the binding target property.</param>
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>
-    /// A converted value.If the method returns null, the valid null value is used.A return value of <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the converter did not produce a value, and that the binding will use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default value.A return value of <see cref="T:System.Windows.Data.Binding" />.<see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
+    /// A converted value.If the method returns null, the valid null value is used.A return value of
+    /// <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" />
+    /// indicates that the converter did not produce a value, and that the binding will use the
+    /// <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default
+    /// value.A return value of <see cref="T:System.Windows.Data.Binding" />.
+    /// <see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or
+    /// use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
     /// </returns>
     /// <exception cref="ArgumentNullException">values.</exception>
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
@@ -42,17 +51,23 @@ public sealed class MultiBooleanOrConverter : IMultiValueConverter
             }
         }
 
-        var invert = parameter?.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true;
+        var invert =
+            parameter?.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true;
         return invert ? !result : result;
     }
 
     /// <summary>Convert back not supported.</summary>
     /// <param name="value">The value that the binding target produces.</param>
-    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of values that are suggested for the method to return.</param>
+    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of
+    /// values that are suggested for the method to return.</param>
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>
     /// An array of values that have been converted from the target value back to the source values.
     /// </returns>
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => targetTypes.Select(t => Binding.DoNothing).ToArray();
+    public object[] ConvertBack(
+        object value,
+        Type[] targetTypes,
+        object parameter,
+        CultureInfo culture) => targetTypes.Select(t => Binding.DoNothing).ToArray();
 }

--- a/src/XamlConverters/Boolean/NullToBoolConverter.cs
+++ b/src/XamlConverters/Boolean/NullToBoolConverter.cs
@@ -10,10 +10,10 @@ namespace CP.Xaml.Converters;
 /// <summary>A simple converter for determining if the specified value is null.</summary>
 public class NullToBoolConverter : IValueConverter
 {
-    /// <summary>Gets an instance of <see cref="NullToBoolConverter"/> that returns true if the specified value is null.</summary>
+    /// <summary>Gets a converter that returns true for a null value.</summary>
     public static NullToBoolConverter IsNull { get; } = new() { ReturnTrueIfNull = true };
 
-    /// <summary>Gets an instance of <see cref="NullToBoolConverter"/> that returns true if the specified value is not null.</summary>
+    /// <summary>Gets a converter that returns true for a non-null value.</summary>
     public static NullToBoolConverter NotNull { get; } = new() { ReturnTrueIfNull = false };
 
     /// <summary>Gets or sets a value indicating whether [return true if null].</summary>
@@ -26,7 +26,8 @@ public class NullToBoolConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => ReturnTrueIfNull ? value is null : value is not null;
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        ReturnTrueIfNull ? value is null : value is not null;
 
     /// <summary>Converts a value.</summary>
     /// <param name="value">The value that is produced by the binding target.</param>
@@ -34,5 +35,9 @@ public class NullToBoolConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Boolean/StringNullOrEmptyToBoolConverter.cs
+++ b/src/XamlConverters/Boolean/StringNullOrEmptyToBoolConverter.cs
@@ -22,7 +22,11 @@ public sealed class StringNullOrEmptyToBoolConverter : IValueConverter
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         var isNullOrEmpty = string.IsNullOrEmpty(value as string);
-        var invert = parameter is not null && (parameter.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true || parameter.ToString()?.Equals("true", StringComparison.OrdinalIgnoreCase) == true);
+        var invert =
+            parameter is not null
+            && (
+                parameter.ToString()?.Equals("invert", StringComparison.OrdinalIgnoreCase) == true
+                || parameter.ToString()?.Equals("true", StringComparison.OrdinalIgnoreCase) == true);
         return invert ? !isNullOrEmpty : isNullOrEmpty;
     }
 
@@ -34,5 +38,9 @@ public sealed class StringNullOrEmptyToBoolConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Boolean/ValueNotNullToBoolConverter.cs
+++ b/src/XamlConverters/Boolean/ValueNotNullToBoolConverter.cs
@@ -35,5 +35,9 @@ public sealed class ValueNotNullToBoolConverter : IValueConverter
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
     /// <exception cref="NotImplementedException">Not Implemented Exception.</exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/BrushToColorConverter.cs
+++ b/src/XamlConverters/BrushToColorConverter.cs
@@ -20,12 +20,13 @@ public class BrushToColorConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value switch
-    {
-        SolidColorBrush brush => brush.Color,
-        Color color => color,
-        _ => Colors.Red
-    };
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value switch
+        {
+            SolidColorBrush brush => brush.Color,
+            Color color => color,
+            _ => Colors.Red,
+        };
 
     /// <summary>Converts a value.</summary>
     /// <param name="value">The value that is produced by the binding target.</param>
@@ -35,5 +36,9 @@ public class BrushToColorConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Collections/CollectionContainsConverter.cs
+++ b/src/XamlConverters/Collections/CollectionContainsConverter.cs
@@ -8,7 +8,7 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Determines whether an enumerable or string contains the value supplied as the converter parameter.</summary>
+/// <summary>Checks whether an enumerable or string contains the converter parameter.</summary>
 public sealed class CollectionContainsConverter : IValueConverter
 {
     /// <summary>Searches the source collection for the requested value.</summary>
@@ -53,7 +53,11 @@ public sealed class CollectionContainsConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns><see cref="Binding.DoNothing"/>.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 
     /// <summary>Determines whether a collection item equals the requested value directly or after conversion.</summary>
     /// <param name="item">The collection item.</param>
@@ -62,8 +66,13 @@ public sealed class CollectionContainsConverter : IValueConverter
     /// <returns><see langword="true"/> when the values are equal; otherwise, <see langword="false"/>.</returns>
     private static bool ItemsEqual(object? item, object? requestedValue, CultureInfo culture) =>
         Equals(item, requestedValue)
-        || (item is not null
+        || (
+            item is not null
             && requestedValue is not null
-            && BclConversion.TryChangeType(requestedValue, item.GetType(), culture, out var converted)
+            && BclConversion.TryChangeType(
+                requestedValue,
+                item.GetType(),
+                culture,
+                out var converted)
             && Equals(item, converted));
 }

--- a/src/XamlConverters/Collections/CollectionFirstOrDefaultConverter.cs
+++ b/src/XamlConverters/Collections/CollectionFirstOrDefaultConverter.cs
@@ -17,7 +17,8 @@ public sealed class CollectionFirstOrDefaultConverter : IValueConverter
     /// <param name="targetType">The binding target type.</param>
     /// <param name="parameter">The fallback returned for a null or empty sequence.</param>
     /// <param name="culture">The culture used by the binding.</param>
-    /// <returns>The first item, the configured fallback, or <see cref="Binding.DoNothing"/> for a non-enumerable source.</returns>
+    /// <returns>The first item, the configured fallback, or <see cref="Binding.DoNothing"/> for a non-enumerable
+    /// source.</returns>
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is null || value == DependencyProperty.UnsetValue)
@@ -47,5 +48,9 @@ public sealed class CollectionFirstOrDefaultConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns><see cref="Binding.DoNothing"/>.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Collections/CollectionItemConverter.cs
+++ b/src/XamlConverters/Collections/CollectionItemConverter.cs
@@ -26,7 +26,8 @@ public sealed class CollectionItemConverter : IValueConverter
                 : Binding.DoNothing;
         }
 
-        if (!BclConversion.TryChangeType(parameter, typeof(int), culture, out var convertedIndex)
+        if (
+            !BclConversion.TryChangeType(parameter, typeof(int), culture, out var convertedIndex)
             || convertedIndex is not int index
             || index < 0)
         {
@@ -47,7 +48,11 @@ public sealed class CollectionItemConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns><see cref="Binding.DoNothing"/>.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 
     /// <summary>Gets an item from an enumerable by index.</summary>
     /// <param name="enumerable">The enumerable source.</param>
@@ -58,10 +63,12 @@ public sealed class CollectionItemConverter : IValueConverter
         var currentIndex = 0;
         foreach (var item in enumerable)
         {
-            if (currentIndex++ == index)
+            if (currentIndex == index)
             {
                 return item;
             }
+
+            currentIndex++;
         }
 
         return Binding.DoNothing;

--- a/src/XamlConverters/Collections/CountToBooleanConverter.cs
+++ b/src/XamlConverters/Collections/CountToBooleanConverter.cs
@@ -9,7 +9,8 @@ using System.Windows.Data;
 namespace CP.Xaml.Converters;
 
 /// <summary>
-/// Returns true if collection count satisfies comparison in parameter. Parameter forms: ">0", "==0", "!= 1" etc. Default is >0.
+/// Returns true if collection count satisfies comparison in parameter. Parameter forms: ">0", "==0", "!= 1" etc.
+/// Default is >0.
 /// </summary>
 public sealed class CountToBooleanConverter : IValueConverter
 {
@@ -52,7 +53,11 @@ public sealed class CountToBooleanConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 
     /// <summary>Represents a parsed count comparison.</summary>
     /// <param name="Op">The comparison operator.</param>
@@ -83,15 +88,16 @@ public sealed class CountToBooleanConverter : IValueConverter
         /// <summary>Evaluates the comparison.</summary>
         /// <param name="lhs">The left-hand operand.</param>
         /// <returns>The comparison result.</returns>
-        public bool Evaluate(int lhs) => Op switch
-        {
-            ">" => lhs > Rhs,
-            ">=" => lhs >= Rhs,
-            "<" => lhs < Rhs,
-            "<=" => lhs <= Rhs,
-            "==" => lhs == Rhs,
-            "!=" => lhs != Rhs,
-            _ => false
-        };
+        public bool Evaluate(int lhs) =>
+            Op switch
+            {
+                ">" => lhs > Rhs,
+                ">=" => lhs >= Rhs,
+                "<" => lhs < Rhs,
+                "<=" => lhs <= Rhs,
+                "==" => lhs == Rhs,
+                "!=" => lhs != Rhs,
+                _ => false,
+            };
     }
 }

--- a/src/XamlConverters/Collections/CountToVisibilityConverter.cs
+++ b/src/XamlConverters/Collections/CountToVisibilityConverter.cs
@@ -9,7 +9,8 @@ using System.Windows.Data;
 namespace CP.Xaml.Converters;
 
 /// <summary>
-/// Converts collection Count to Visibility using comparison parameter (see CountToBooleanConverter). Optional token 'H' to use Hidden.
+/// Converts collection Count to Visibility using comparison parameter (see CountToBooleanConverter). Optional token 'H'
+/// to use Hidden.
 /// </summary>
 public sealed class CountToVisibilityConverter : IValueConverter
 {
@@ -29,7 +30,12 @@ public sealed class CountToVisibilityConverter : IValueConverter
         var parm = parameter?.ToString() ?? string.Empty;
         var useHidden = parm.Contains('H');
         var comparisonPart = parm.Replace("H", string.Empty);
-        var result = (bool)_bool.Convert(value, targetType, string.IsNullOrWhiteSpace(comparisonPart) ? null : comparisonPart, culture);
+        var result = (bool)
+            _bool.Convert(
+                value,
+                targetType,
+                string.IsNullOrWhiteSpace(comparisonPart) ? null : comparisonPart,
+                culture);
         if (result)
         {
             return Visibility.Visible;
@@ -46,5 +52,9 @@ public sealed class CountToVisibilityConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Collections/EnumerableToStringConverter.cs
+++ b/src/XamlConverters/Collections/EnumerableToStringConverter.cs
@@ -16,7 +16,8 @@ public sealed class EnumerableToStringConverter : IValueConverter
     /// <param name="targetType">The binding target type.</param>
     /// <param name="parameter">An optional separator; the default is <c>, </c>.</param>
     /// <param name="culture">The culture used to format individual items.</param>
-    /// <returns>The joined string, an empty string for null, or <see cref="Binding.DoNothing"/> for a non-enumerable value.</returns>
+    /// <returns>The joined string, an empty string for null, or <see cref="Binding.DoNothing"/> for a non-enumerable
+    /// value.</returns>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is null)
@@ -38,19 +39,24 @@ public sealed class EnumerableToStringConverter : IValueConverter
         var values = new List<string>();
         foreach (var item in enumerable)
         {
-            values.Add(item is IFormattable formattable
-                ? formattable.ToString(null, culture)
-                : item?.ToString() ?? string.Empty);
+            values.Add(
+                item is IFormattable formattable
+                    ? formattable.ToString(null, culture)
+                    : item?.ToString() ?? string.Empty);
         }
 
         return string.Join(separator, values);
     }
 
-    /// <summary>Reverse conversion is not supported because collection element types and escaping rules are ambiguous.</summary>
+    /// <summary>Reverse conversion is unsupported because element types and escaping rules are ambiguous.</summary>
     /// <param name="value">The target value.</param>
     /// <param name="targetType">The binding source type.</param>
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns><see cref="Binding.DoNothing"/>.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Conversion/BclConversion.cs
+++ b/src/XamlConverters/Conversion/BclConversion.cs
@@ -20,10 +20,14 @@ internal static class BclConversion
     private const NumberStyles FloatingStyles = NumberStyles.Float | NumberStyles.AllowThousands;
 
     /// <summary>The number styles used for decimal values.</summary>
-    private const NumberStyles DecimalStyles = NumberStyles.Number | NumberStyles.AllowCurrencySymbol | NumberStyles.AllowParentheses;
+    private const NumberStyles DecimalStyles =
+        NumberStyles.Number | NumberStyles.AllowCurrencySymbol | NumberStyles.AllowParentheses;
 
-    /// <summary>Converters for well-known types that are not handled consistently by <see cref="System.Convert"/>.</summary>
-    private static readonly Dictionary<Type, Func<object, string?, CultureInfo, ConversionAttempt>> SpecialConverters = new()
+    /// <summary>Converters for well-known types not handled consistently by <see cref="System.Convert"/>.</summary>
+    private static readonly Dictionary<
+        Type,
+        Func<object, string?, CultureInfo, ConversionAttempt>
+    > SpecialConverters = new()
     {
         [typeof(Guid)] = TryConvertGuid,
         [typeof(Uri)] = TryConvertUri,
@@ -35,20 +39,21 @@ internal static class BclConversion
     };
 
     /// <summary>Parsers for the built-in numeric types.</summary>
-    private static readonly Dictionary<TypeCode, Func<string, CultureInfo, object>> NumericParsers = new()
-    {
-        [TypeCode.Byte] = (text, culture) => byte.Parse(text, IntegerStyles, culture),
-        [TypeCode.Decimal] = (text, culture) => decimal.Parse(text, DecimalStyles, culture),
-        [TypeCode.Double] = (text, culture) => double.Parse(text, FloatingStyles, culture),
-        [TypeCode.Int16] = (text, culture) => short.Parse(text, IntegerStyles, culture),
-        [TypeCode.Int32] = (text, culture) => int.Parse(text, IntegerStyles, culture),
-        [TypeCode.Int64] = (text, culture) => long.Parse(text, IntegerStyles, culture),
-        [TypeCode.SByte] = (text, culture) => sbyte.Parse(text, IntegerStyles, culture),
-        [TypeCode.Single] = (text, culture) => float.Parse(text, FloatingStyles, culture),
-        [TypeCode.UInt16] = (text, culture) => ushort.Parse(text, IntegerStyles, culture),
-        [TypeCode.UInt32] = (text, culture) => uint.Parse(text, IntegerStyles, culture),
-        [TypeCode.UInt64] = (text, culture) => ulong.Parse(text, IntegerStyles, culture),
-    };
+    private static readonly Dictionary<TypeCode, Func<string, CultureInfo, object>> NumericParsers =
+        new()
+        {
+            [TypeCode.Byte] = (text, culture) => byte.Parse(text, IntegerStyles, culture),
+            [TypeCode.Decimal] = (text, culture) => decimal.Parse(text, DecimalStyles, culture),
+            [TypeCode.Double] = (text, culture) => double.Parse(text, FloatingStyles, culture),
+            [TypeCode.Int16] = (text, culture) => short.Parse(text, IntegerStyles, culture),
+            [TypeCode.Int32] = (text, culture) => int.Parse(text, IntegerStyles, culture),
+            [TypeCode.Int64] = (text, culture) => long.Parse(text, IntegerStyles, culture),
+            [TypeCode.SByte] = (text, culture) => sbyte.Parse(text, IntegerStyles, culture),
+            [TypeCode.Single] = (text, culture) => float.Parse(text, FloatingStyles, culture),
+            [TypeCode.UInt16] = (text, culture) => ushort.Parse(text, IntegerStyles, culture),
+            [TypeCode.UInt32] = (text, culture) => uint.Parse(text, IntegerStyles, culture),
+            [TypeCode.UInt64] = (text, culture) => ulong.Parse(text, IntegerStyles, culture),
+        };
 
     /// <summary>Represents the outcome of a direct conversion attempt.</summary>
     private enum ConversionResult
@@ -63,13 +68,17 @@ internal static class BclConversion
         Failed,
     }
 
-    /// <summary>Attempts to convert a value to the requested target type without throwing conversion exceptions.</summary>
+    /// <summary>Attempts to convert a value without throwing conversion exceptions.</summary>
     /// <param name="value">The source value.</param>
     /// <param name="targetType">The requested target type.</param>
     /// <param name="culture">The culture to use for parsing and formatting.</param>
     /// <param name="result">The converted result when conversion succeeds.</param>
     /// <returns><see langword="true"/> when conversion succeeds; otherwise, <see langword="false"/>.</returns>
-    public static bool TryChangeType(object? value, Type targetType, CultureInfo culture, out object? result)
+    public static bool TryChangeType(
+        object? value,
+        Type targetType,
+        CultureInfo culture,
+        out object? result)
     {
         if (targetType is null)
         {
@@ -79,7 +88,13 @@ internal static class BclConversion
         var nullableType = Nullable.GetUnderlyingType(targetType);
         var destinationType = nullableType ?? targetType;
         var text = value as string;
-        var directResult = TryDirectConversion(value, destinationType, nullableType, text, culture, out result);
+        var directResult = TryDirectConversion(
+            value,
+            destinationType,
+            nullableType,
+            text,
+            culture,
+            out result);
         if (directResult != ConversionResult.NotHandled)
         {
             return directResult == ConversionResult.Succeeded;
@@ -146,7 +161,9 @@ internal static class BclConversion
         if (IsNullValue(value))
         {
             result = null;
-            return CanAcceptNull(destinationType, nullableType) ? ConversionResult.Succeeded : ConversionResult.Failed;
+            return CanAcceptNull(destinationType, nullableType)
+                ? ConversionResult.Succeeded
+                : ConversionResult.Failed;
         }
 
         if (IsDirectlyAssignable(value!, destinationType))
@@ -182,12 +199,14 @@ internal static class BclConversion
     /// <param name="destinationType">The non-nullable destination type.</param>
     /// <param name="nullableType">The nullable destination type, when applicable.</param>
     /// <returns><see langword="true"/> when null is accepted; otherwise, <see langword="false"/>.</returns>
-    private static bool CanAcceptNull(Type destinationType, Type? nullableType) => nullableType is not null || !destinationType.IsValueType;
+    private static bool CanAcceptNull(Type destinationType, Type? nullableType) =>
+        nullableType is not null || !destinationType.IsValueType;
 
     /// <summary>Determines whether a value is already assignable to the destination type.</summary>
     /// <param name="value">The source value.</param>
     /// <param name="destinationType">The destination type.</param>
-    /// <returns><see langword="true"/> when the value is directly assignable; otherwise, <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> when the value is directly assignable; otherwise, <see langword="false"/>.
+    /// </returns>
     private static bool IsDirectlyAssignable(object value, Type destinationType) =>
         destinationType == typeof(object) || destinationType.IsInstanceOfType(value);
 
@@ -195,16 +214,18 @@ internal static class BclConversion
     /// <param name="text">The source text.</param>
     /// <param name="nullableType">The nullable destination type, when applicable.</param>
     /// <returns><see langword="true"/> when the nullable text is empty; otherwise, <see langword="false"/>.</returns>
-    private static bool IsEmptyNullableText(string? text, Type? nullableType) => nullableType is not null && string.IsNullOrWhiteSpace(text);
+    private static bool IsEmptyNullableText(string? text, Type? nullableType) =>
+        nullableType is not null && string.IsNullOrWhiteSpace(text);
 
     /// <summary>Converts a string or numeric value to an enum.</summary>
     /// <param name="value">The source value.</param>
     /// <param name="enumType">The enum type.</param>
     /// <param name="text">The source text, when applicable.</param>
     /// <returns>The enum value.</returns>
-    private static object ConvertEnum(object value, Type enumType, string? text) => text is not null
-        ? Enum.Parse(enumType, text, ignoreCase: true)
-        : Enum.ToObject(enumType, value);
+    private static object ConvertEnum(object value, Type enumType, string? text) =>
+        text is not null
+            ? Enum.Parse(enumType, text, ignoreCase: true)
+            : Enum.ToObject(enumType, value);
 
     /// <summary>Attempts a conversion through the strategy registered for a well-known destination type.</summary>
     /// <param name="value">The source value.</param>
@@ -213,7 +234,12 @@ internal static class BclConversion
     /// <param name="culture">The conversion culture.</param>
     /// <param name="result">The converted result.</param>
     /// <returns><see langword="true"/> when conversion succeeds; otherwise, <see langword="false"/>.</returns>
-    private static bool TrySpecialConversion(object value, string? text, Type destinationType, CultureInfo culture, out object? result)
+    private static bool TrySpecialConversion(
+        object value,
+        string? text,
+        Type destinationType,
+        CultureInfo culture,
+        out object? result)
     {
         if (SpecialConverters.TryGetValue(destinationType, out var converter))
         {
@@ -232,9 +258,15 @@ internal static class BclConversion
     /// <param name="culture">The parsing culture.</param>
     /// <param name="result">The parsed result.</param>
     /// <returns><see langword="true"/> when parsing is available; otherwise, <see langword="false"/>.</returns>
-    private static bool TryConvertNumeric(string? text, Type destinationType, CultureInfo culture, out object? result)
+    private static bool TryConvertNumeric(
+        string? text,
+        Type destinationType,
+        CultureInfo culture,
+        out object? result)
     {
-        if (text is null || !NumericParsers.TryGetValue(Type.GetTypeCode(destinationType), out var parser))
+        if (
+            text is null
+            || !NumericParsers.TryGetValue(Type.GetTypeCode(destinationType), out var parser))
         {
             result = null;
             return false;
@@ -250,7 +282,11 @@ internal static class BclConversion
     /// <param name="culture">The conversion culture.</param>
     /// <param name="result">The converted result.</param>
     /// <returns><see langword="true"/> when a type converter succeeds; otherwise, <see langword="false"/>.</returns>
-    private static bool TryTypeConverters(object value, Type destinationType, CultureInfo culture, out object? result)
+    private static bool TryTypeConverters(
+        object value,
+        Type destinationType,
+        CultureInfo culture,
+        out object? result)
     {
         var destinationConverter = TypeDescriptor.GetConverter(destinationType);
         if (destinationConverter.CanConvertFrom(value.GetType()))
@@ -295,7 +331,10 @@ internal static class BclConversion
     private static ConversionAttempt TryConvertUri(object value, string? text, CultureInfo culture)
     {
         _ = culture;
-        var success = Uri.TryCreate(text ?? value.ToString(), UriKind.RelativeOrAbsolute, out var uri);
+        var success = Uri.TryCreate(
+            text ?? value.ToString(),
+            UriKind.RelativeOrAbsolute,
+            out var uri);
         return new(success, uri);
     }
 
@@ -304,7 +343,10 @@ internal static class BclConversion
     /// <param name="text">The source text, when applicable.</param>
     /// <param name="culture">The conversion culture.</param>
     /// <returns>The conversion status and result.</returns>
-    private static ConversionAttempt TryConvertTimeSpan(object value, string? text, CultureInfo culture)
+    private static ConversionAttempt TryConvertTimeSpan(
+        object value,
+        string? text,
+        CultureInfo culture)
     {
         var success = TimeSpan.TryParse(text ?? value.ToString(), culture, out var timeSpan);
         return new(success, success ? timeSpan : null);
@@ -315,14 +357,21 @@ internal static class BclConversion
     /// <param name="text">The source text, when applicable.</param>
     /// <param name="culture">The conversion culture.</param>
     /// <returns>The conversion status and result.</returns>
-    private static ConversionAttempt TryConvertDateTimeOffset(object value, string? text, CultureInfo culture)
+    private static ConversionAttempt TryConvertDateTimeOffset(
+        object value,
+        string? text,
+        CultureInfo culture)
     {
         if (value is DateTime dateTime)
         {
             return new(true, new DateTimeOffset(dateTime));
         }
 
-        var success = DateTimeOffset.TryParse(text ?? value.ToString(), culture, DateTimeStyles.AllowWhiteSpaces, out var offset);
+        var success = DateTimeOffset.TryParse(
+            text ?? value.ToString(),
+            culture,
+            DateTimeStyles.AllowWhiteSpaces,
+            out var offset);
         return new(success, success ? offset : null);
     }
 
@@ -331,7 +380,10 @@ internal static class BclConversion
     /// <param name="text">The source text, when applicable.</param>
     /// <param name="culture">The conversion culture.</param>
     /// <returns>The conversion status and result.</returns>
-    private static ConversionAttempt TryConvertDateTime(object value, string? text, CultureInfo culture)
+    private static ConversionAttempt TryConvertDateTime(
+        object value,
+        string? text,
+        CultureInfo culture)
     {
         _ = text;
         _ = culture;
@@ -348,7 +400,9 @@ internal static class BclConversion
     {
         _ = value;
         _ = culture;
-        var result = text is null ? null : Type.GetType(text, throwOnError: false, ignoreCase: true);
+        var result = text is null
+            ? null
+            : Type.GetType(text, throwOnError: false, ignoreCase: true);
         return new(result is not null, result);
     }
 
@@ -357,7 +411,10 @@ internal static class BclConversion
     /// <param name="text">The source text, when applicable.</param>
     /// <param name="culture">The conversion culture.</param>
     /// <returns>The conversion status and result.</returns>
-    private static ConversionAttempt TryConvertBoolean(object value, string? text, CultureInfo culture)
+    private static ConversionAttempt TryConvertBoolean(
+        object value,
+        string? text,
+        CultureInfo culture)
     {
         _ = value;
         _ = culture;
@@ -366,21 +423,31 @@ internal static class BclConversion
             return new(true, boolean);
         }
 
-        if (string.Equals(text, "yes", StringComparison.OrdinalIgnoreCase) || string.Equals(text, "on", StringComparison.OrdinalIgnoreCase))
+        if (
+            string.Equals(text, "yes", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(text, "on", StringComparison.OrdinalIgnoreCase))
         {
             return new(true, true);
         }
 
-        return string.Equals(text, "no", StringComparison.OrdinalIgnoreCase) || string.Equals(text, "off", StringComparison.OrdinalIgnoreCase)
-            ? new ConversionAttempt(true, false)
-            : new ConversionAttempt(false, null);
+        return
+            string.Equals(text, "no", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(text, "off", StringComparison.OrdinalIgnoreCase)
+                ? new ConversionAttempt(true, false)
+                : new ConversionAttempt(false, null);
     }
 
     /// <summary>Determines whether an exception represents a recoverable conversion failure.</summary>
     /// <param name="exception">The exception to inspect.</param>
-    /// <returns><see langword="true"/> for a recoverable conversion failure; otherwise, <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> for a recoverable conversion failure; otherwise, <see langword="false"/>.
+    /// </returns>
     private static bool IsConversionException(Exception exception) =>
-        exception is ArgumentException or FormatException or InvalidCastException or NotSupportedException or OverflowException;
+        exception
+            is ArgumentException
+                or FormatException
+                or InvalidCastException
+                or NotSupportedException
+                or OverflowException;
 
     /// <summary>Stores the outcome of a special conversion attempt.</summary>
     private sealed class ConversionAttempt

--- a/src/XamlConverters/ConvertersRegistry.cs
+++ b/src/XamlConverters/ConvertersRegistry.cs
@@ -4,7 +4,7 @@
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Static registry exposing singleton instances for commonly reused stateless converters to reduce XAML noise.</summary>
+/// <summary>Provides singleton instances of commonly reused stateless converters.</summary>
 public static class ConvertersRegistry
 {
     /// <summary>Converts between compatible BCL types.</summary>

--- a/src/XamlConverters/DateTime/DateTimeFormatConverter.cs
+++ b/src/XamlConverters/DateTime/DateTimeFormatConverter.cs
@@ -24,7 +24,9 @@ public sealed class DateTimeFormatConverter : IValueConverter
             return dateTime.ToString(format, culture);
         }
 
-        return value is DateTimeOffset dateTimeOffset ? dateTimeOffset.ToString(format, culture) : Binding.DoNothing;
+        return value is DateTimeOffset dateTimeOffset
+            ? dateTimeOffset.ToString(format, culture)
+            : Binding.DoNothing;
     }
 
     /// <summary>Parses formatted text back to <see cref="System.DateTime"/> or <see cref="DateTimeOffset"/>.</summary>
@@ -33,7 +35,11 @@ public sealed class DateTimeFormatConverter : IValueConverter
     /// <param name="parameter">An optional exact date/time format.</param>
     /// <param name="culture">The culture used for parsing.</param>
     /// <returns>The parsed date/time value, or <see cref="Binding.DoNothing"/> when parsing fails.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         var text = value as string;
         if (string.IsNullOrWhiteSpace(text))
@@ -46,16 +52,34 @@ public sealed class DateTimeFormatConverter : IValueConverter
         if (destinationType == typeof(DateTime))
         {
             var parsed = string.IsNullOrWhiteSpace(format)
-                ? System.DateTime.TryParse(text, culture, DateTimeStyles.AllowWhiteSpaces, out var dateTime)
-                : System.DateTime.TryParseExact(text, format, culture, DateTimeStyles.AllowWhiteSpaces, out dateTime);
+                ? System.DateTime.TryParse(
+                    text,
+                    culture,
+                    DateTimeStyles.AllowWhiteSpaces,
+                    out var dateTime)
+                : System.DateTime.TryParseExact(
+                    text,
+                    format,
+                    culture,
+                    DateTimeStyles.AllowWhiteSpaces,
+                    out dateTime);
             return parsed ? dateTime : Binding.DoNothing;
         }
 
         if (destinationType == typeof(DateTimeOffset))
         {
             var parsed = string.IsNullOrWhiteSpace(format)
-                ? DateTimeOffset.TryParse(text, culture, DateTimeStyles.AllowWhiteSpaces, out var dateTimeOffset)
-                : DateTimeOffset.TryParseExact(text, format, culture, DateTimeStyles.AllowWhiteSpaces, out dateTimeOffset);
+                ? DateTimeOffset.TryParse(
+                    text,
+                    culture,
+                    DateTimeStyles.AllowWhiteSpaces,
+                    out var dateTimeOffset)
+                : DateTimeOffset.TryParseExact(
+                    text,
+                    format,
+                    culture,
+                    DateTimeStyles.AllowWhiteSpaces,
+                    out dateTimeOffset);
             return parsed ? dateTimeOffset : Binding.DoNothing;
         }
 

--- a/src/XamlConverters/Enum/EnumDescriptionConverter.cs
+++ b/src/XamlConverters/Enum/EnumDescriptionConverter.cs
@@ -20,7 +20,9 @@ public sealed class EnumDescriptionConverter : IValueConverter
     /// <returns>The description, member name, or <see cref="Binding.DoNothing"/> for a non-enum value.</returns>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        return value is not Enum enumValue ? Binding.DoNothing : GetDescription(enumValue.GetType(), enumValue.ToString());
+        return value is not Enum enumValue
+            ? Binding.DoNothing
+            : GetDescription(enumValue.GetType(), enumValue.ToString());
     }
 
     /// <summary>Finds an enum member by description or member name.</summary>
@@ -29,7 +31,11 @@ public sealed class EnumDescriptionConverter : IValueConverter
     /// <param name="parameter">An optional enum <see cref="Type"/> when the source type is not available.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns>The matching enum value, or <see cref="Binding.DoNothing"/> when no member matches.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         if (targetType is null)
         {
@@ -45,8 +51,12 @@ public sealed class EnumDescriptionConverter : IValueConverter
         var text = value.ToString();
         foreach (var name in Enum.GetNames(enumType))
         {
-            if (string.Equals(name, text, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(GetDescription(enumType, name), text, StringComparison.CurrentCultureIgnoreCase))
+            if (
+                string.Equals(name, text, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(
+                    GetDescription(enumType, name),
+                    text,
+                    StringComparison.CurrentCultureIgnoreCase))
             {
                 return Enum.Parse(enumType, name, ignoreCase: true);
             }
@@ -63,10 +73,13 @@ public sealed class EnumDescriptionConverter : IValueConverter
     /// <returns>The description text, or the member name when no description exists.</returns>
     private static string GetDescription(Type enumType, string memberName)
     {
-        var member = enumType.GetMember(memberName, BindingFlags.Public | BindingFlags.Static).FirstOrDefault();
+        var member = enumType
+            .GetMember(memberName, BindingFlags.Public | BindingFlags.Static)
+            .FirstOrDefault();
         var description = member is null
             ? null
-            : Attribute.GetCustomAttribute(member, typeof(DescriptionAttribute)) as DescriptionAttribute;
+            : Attribute.GetCustomAttribute(member, typeof(DescriptionAttribute))
+                as DescriptionAttribute;
         return description?.Description ?? memberName;
     }
 }

--- a/src/XamlConverters/Enum/EnumHasFlagConverter.cs
+++ b/src/XamlConverters/Enum/EnumHasFlagConverter.cs
@@ -18,8 +18,13 @@ public sealed class EnumHasFlagConverter : IValueConverter
     /// <returns><see langword="true"/> when all requested bits are present.</returns>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is not Enum enumValue
-            || !BclConversion.TryChangeType(parameter, enumValue.GetType(), culture, out var convertedFlag)
+        if (
+            value is not Enum enumValue
+            || !BclConversion.TryChangeType(
+                parameter,
+                enumValue.GetType(),
+                culture,
+                out var convertedFlag)
             || convertedFlag is not Enum flag)
         {
             return false;
@@ -30,13 +35,17 @@ public sealed class EnumHasFlagConverter : IValueConverter
         return (valueBits & flagBits) == flagBits;
     }
 
-    /// <summary>Reverse conversion is not supported because removing a flag requires the complete current source value.</summary>
+    /// <summary>Reverse conversion is unsupported because removing a flag requires the current source value.</summary>
     /// <param name="value">The target value.</param>
     /// <param name="targetType">The binding source type.</param>
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns><see cref="Binding.DoNothing"/>.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 
     /// <summary>Converts an enum value to its unsigned bit representation.</summary>
     /// <param name="value">The enum value.</param>

--- a/src/XamlConverters/Enum/EnumValuesConverter.cs
+++ b/src/XamlConverters/Enum/EnumValuesConverter.cs
@@ -20,9 +20,7 @@ public sealed class EnumValuesConverter : IValueConverter
     {
         var enumType = (parameter as Type) ?? (value as Type) ?? value?.GetType();
         enumType = enumType is null ? null : Nullable.GetUnderlyingType(enumType) ?? enumType;
-        return enumType?.IsEnum == true
-            ? Enum.GetValues(enumType)
-            : Binding.DoNothing;
+        return enumType?.IsEnum == true ? Enum.GetValues(enumType) : Binding.DoNothing;
     }
 
     /// <summary>Reverse conversion is not supported.</summary>
@@ -31,5 +29,9 @@ public sealed class EnumValuesConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns><see cref="Binding.DoNothing"/>.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/FallbackBrushConverter.cs
+++ b/src/XamlConverters/FallbackBrushConverter.cs
@@ -20,12 +20,13 @@ public class FallbackBrushConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value switch
-    {
-        SolidColorBrush brush => brush,
-        Color color => new SolidColorBrush(color),
-        _ => new SolidColorBrush(Colors.Red)
-    };
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value switch
+        {
+            SolidColorBrush brush => brush,
+            Color color => new SolidColorBrush(color),
+            _ => new SolidColorBrush(Colors.Red),
+        };
 
     /// <summary>Converts a value.</summary>
     /// <param name="value">The value that is produced by the binding target.</param>
@@ -35,5 +36,9 @@ public class FallbackBrushConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Generic/ByteArrayToBase64Converter.cs
+++ b/src/XamlConverters/Generic/ByteArrayToBase64Converter.cs
@@ -16,7 +16,8 @@ public sealed class ByteArrayToBase64Converter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns>The converted value, or <see cref="Binding.DoNothing"/> for invalid input.</returns>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        ConvertCore(value, targetType);
 
     /// <summary>Decodes Base64 text to bytes, or encodes bytes when the source is a string.</summary>
     /// <param name="value">The target value.</param>
@@ -24,7 +25,11 @@ public sealed class ByteArrayToBase64Converter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns>The converted value, or <see cref="Binding.DoNothing"/> for invalid input.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConvertCore(value, targetType);
 
     /// <summary>Converts between byte arrays and Base64 text.</summary>
     /// <param name="value">The source value.</param>
@@ -37,7 +42,9 @@ public sealed class ByteArrayToBase64Converter : IValueConverter
             return System.Convert.ToBase64String(bytes);
         }
 
-        if (value is not string text || (targetType != typeof(byte[]) && targetType != typeof(object)))
+        if (
+            value is not string text
+            || (targetType != typeof(byte[]) && targetType != typeof(object)))
         {
             return Binding.DoNothing;
         }

--- a/src/XamlConverters/Generic/ChangeTypeConverter.cs
+++ b/src/XamlConverters/Generic/ChangeTypeConverter.cs
@@ -8,14 +8,14 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Converts between compatible BCL types by using enum, nullable, parsing, type-converter, and <see cref="Convert.ChangeType(object, Type, IFormatProvider)"/> semantics.</summary>
+/// <summary>Converts between compatible BCL types using standard conversion semantics.</summary>
 /// <remarks>
 /// Supply a <see cref="Type"/> as the converter parameter to override the binding target type.
 /// Conversion failures return <see cref="Binding.DoNothing"/>.
 /// </remarks>
 public sealed class ChangeTypeConverter : IValueConverter
 {
-    /// <summary>Converts the source value to the binding target type, or to the type supplied as the parameter.</summary>
+    /// <summary>Converts the source value to the target or parameter type.</summary>
     /// <param name="value">The source value.</param>
     /// <param name="targetType">The binding target type.</param>
     /// <param name="parameter">An optional <see cref="Type"/> that overrides <paramref name="targetType"/>.</param>
@@ -40,7 +40,11 @@ public sealed class ChangeTypeConverter : IValueConverter
     /// <param name="parameter">The converter parameter; it is not needed for reverse conversion.</param>
     /// <param name="culture">The culture used for conversion.</param>
     /// <returns>The converted value, or <see cref="Binding.DoNothing"/> when conversion fails.</returns>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
         BclConversion.TryChangeType(value, targetType, culture, out var result)
             ? result
             : Binding.DoNothing;

--- a/src/XamlConverters/Generic/ComparisonConverter.cs
+++ b/src/XamlConverters/Generic/ComparisonConverter.cs
@@ -28,7 +28,9 @@ public sealed class ComparisonConverter : IValueConverter
     private static readonly Regex _pattern = WpfComparisonRegexProvider.Create();
 #else
     /// <summary>The compiled comparison parameter expression.</summary>
-    private static readonly Regex _pattern = new("^(?<invert>!{0,1})(?<op>>=|<=|==|!=|>|<)\\s{0,}(?<rhs>.+)$", RegexOptions.Compiled);
+    private static readonly Regex _pattern = new(
+        "^(?<invert>!{0,1})(?<op>>=|<=|==|!=|>|<)\\s{0,}(?<rhs>.+)$",
+        RegexOptions.Compiled);
 #endif
 
     /// <summary>Executes the comparison.</summary>
@@ -59,14 +61,19 @@ public sealed class ComparisonConverter : IValueConverter
         if (value is IComparable)
         {
             // Try to coerce numeric types.
-            if (double.TryParse(rhsText, NumberStyles.Any, culture, out var rhsDouble) && value is not string)
+            if (
+                double.TryParse(rhsText, NumberStyles.Any, culture, out var rhsDouble)
+                && value is not string)
             {
                 var lhsDouble = System.Convert.ToDouble(value, culture);
                 comparison = lhsDouble.CompareTo(rhsDouble);
             }
             else
             {
-                comparison = string.Compare(value?.ToString(), rhsText, StringComparison.OrdinalIgnoreCase);
+                comparison = string.Compare(
+                    value?.ToString(),
+                    rhsText,
+                    StringComparison.OrdinalIgnoreCase);
             }
         }
         else
@@ -94,5 +101,9 @@ public sealed class ComparisonConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>Binding.DoNothing.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Generic/EqualityConverter.cs
+++ b/src/XamlConverters/Generic/EqualityConverter.cs
@@ -43,5 +43,9 @@ public sealed class EqualityConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Generic/GuidConverter.cs
+++ b/src/XamlConverters/Generic/GuidConverter.cs
@@ -13,7 +13,8 @@ public sealed class GuidConverter : IValueConverter
     /// <summary>Converts a GUID to text or converts text/bytes to a GUID according to the target type.</summary>
     /// <param name="value">A GUID, GUID string, or 16-byte array.</param>
     /// <param name="targetType">The binding target type.</param>
-    /// <param name="parameter">An optional GUID format such as <c>D</c>, <c>N</c>, <c>B</c>, <c>P</c>, or <c>X</c>.</param>
+    /// <param name="parameter">An optional GUID format such as <c>D</c>, <c>N</c>, <c>B</c>, <c>P</c>, or <c>X</c>.
+    /// </param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns>The converted value, or <see cref="Binding.DoNothing"/> when conversion fails.</returns>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -45,13 +46,17 @@ public sealed class GuidConverter : IValueConverter
             : Binding.DoNothing;
     }
 
-    /// <summary>Converts a target representation back to the requested GUID, string, or byte-array source type.</summary>
+    /// <summary>Converts a target value back to a GUID, string, or byte array.</summary>
     /// <param name="value">The target value.</param>
     /// <param name="targetType">The binding source type.</param>
     /// <param name="parameter">An optional GUID format.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns>The converted value, or <see cref="Binding.DoNothing"/> when conversion fails.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture)
     {
         if (targetType == typeof(string) && value is Guid guid)
         {

--- a/src/XamlConverters/Generic/ObjectEqualsParameterConverter.cs
+++ b/src/XamlConverters/Generic/ObjectEqualsParameterConverter.cs
@@ -7,7 +7,7 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Returns true if object's ToString() equals parameter (case-insensitive). Prefix parameter with ! to invert.</summary>
+/// <summary>Compares an object's text with the parameter, using a leading ! to invert the result.</summary>
 public sealed class ObjectEqualsParameterConverter : IValueConverter
 {
     /// <summary>Compares the bound value string representation with the parameter.</summary>
@@ -43,5 +43,9 @@ public sealed class ObjectEqualsParameterConverter : IValueConverter
     /// <returns>
     /// Binding.DoNothing.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Generic/ObjectToTypeNameConverter.cs
+++ b/src/XamlConverters/Generic/ObjectToTypeNameConverter.cs
@@ -25,7 +25,8 @@ public sealed class ObjectToTypeNameConverter : IValueConverter
             return string.Empty;
         }
 
-        var full = parameter?.ToString()?.Equals("full", StringComparison.OrdinalIgnoreCase) == true;
+        var full =
+            parameter?.ToString()?.Equals("full", StringComparison.OrdinalIgnoreCase) == true;
         var t = value.GetType();
         return full ? t.FullName ?? t.Name : t.Name;
     }
@@ -38,5 +39,9 @@ public sealed class ObjectToTypeNameConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Generic/TypeMatchConverter.cs
+++ b/src/XamlConverters/Generic/TypeMatchConverter.cs
@@ -51,7 +51,11 @@ public sealed class TypeMatchConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns><see cref="Binding.DoNothing"/>.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => Binding.DoNothing;
 
     /// <summary>Determines whether any supported type name matches the requested name.</summary>
     /// <param name="type">The type to inspect.</param>
@@ -60,5 +64,8 @@ public sealed class TypeMatchConverter : IValueConverter
     private static bool MatchesName(Type type, string expectedName) =>
         string.Equals(type.Name, expectedName, StringComparison.OrdinalIgnoreCase)
         || string.Equals(type.FullName, expectedName, StringComparison.OrdinalIgnoreCase)
-        || string.Equals(type.AssemblyQualifiedName, expectedName, StringComparison.OrdinalIgnoreCase);
+        || string.Equals(
+            type.AssemblyQualifiedName,
+            expectedName,
+            StringComparison.OrdinalIgnoreCase);
 }

--- a/src/XamlConverters/Generic/UriConverter.cs
+++ b/src/XamlConverters/Generic/UriConverter.cs
@@ -20,7 +20,8 @@ public sealed class UriConverter : IValueConverter
     /// <param name="parameter">An optional <see cref="UriKind"/>.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns>The converted value, or <see cref="Binding.DoNothing"/> when the URI is invalid.</returns>
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType, parameter);
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        ConvertCore(value, targetType, parameter);
 
     /// <summary>Converts the target URI representation back to the requested source type.</summary>
     /// <param name="value">The target value.</param>
@@ -28,7 +29,11 @@ public sealed class UriConverter : IValueConverter
     /// <param name="parameter">An optional <see cref="UriKind"/>.</param>
     /// <param name="culture">The culture used by the binding.</param>
     /// <returns>The converted value, or <see cref="Binding.DoNothing"/> when the URI is invalid.</returns>
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => ConvertCore(value, targetType, parameter);
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) => ConvertCore(value, targetType, parameter);
 
     /// <summary>Converts between URI values and text.</summary>
     /// <param name="value">The source value.</param>

--- a/src/XamlConverters/HexStringToColorConverter.cs
+++ b/src/XamlConverters/HexStringToColorConverter.cs
@@ -33,8 +33,7 @@ public class HexStringToColorConverter : IValueConverter
         'C',
         'D',
         'E',
-        'F'
-    ];
+        'F',];
 
     /// <summary>Appends the hexadecimal.</summary>
     /// <param name="colorValue">The color value.</param>
@@ -62,7 +61,11 @@ public class HexStringToColorConverter : IValueConverter
         }
 
         var colorValue = uint.Parse(text, NumberStyles.HexNumber);
-        return Color.FromArgb(byte.MaxValue, (byte)((colorValue & 0xff0000) >> 16), (byte)((colorValue & 0x00ff00) >> 8), (byte)(colorValue & 0x0000ff));
+        return Color.FromArgb(
+            byte.MaxValue,
+            (byte)((colorValue & 0xff0000) >> 16),
+            (byte)((colorValue & 0x00ff00) >> 8),
+            (byte)(colorValue & 0x0000ff));
     }
 
     /// <summary>Converts a value.</summary>

--- a/src/XamlConverters/HexStringToSolidColorBrushConverter.cs
+++ b/src/XamlConverters/HexStringToSolidColorBrushConverter.cs
@@ -33,8 +33,7 @@ public class HexStringToSolidColorBrushConverter : IValueConverter
         'C',
         'D',
         'E',
-        'F'
-    ];
+        'F',];
 
     /// <summary>Appends the hexadecimal.</summary>
     /// <param name="colorValue">The color value.</param>
@@ -64,7 +63,11 @@ public class HexStringToSolidColorBrushConverter : IValueConverter
         var colorValue = uint.Parse(text, NumberStyles.HexNumber);
         return new SolidColorBrush()
         {
-            Color = Color.FromArgb(byte.MaxValue, (byte)((colorValue & 0xff0000) >> 16), (byte)((colorValue & 0x00ff00) >> 8), (byte)(colorValue & 0x0000ff))
+            Color = Color.FromArgb(
+                byte.MaxValue,
+                (byte)((colorValue & 0xff0000) >> 16),
+                (byte)((colorValue & 0x00ff00) >> 8),
+                (byte)(colorValue & 0x0000ff)),
         };
     }
 

--- a/src/XamlConverters/IntToThicknessConverter.cs
+++ b/src/XamlConverters/IntToThicknessConverter.cs
@@ -8,19 +8,19 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Converts an integer into a thickness value, building on top of the converter parameter if specified.</summary>
+/// <summary>Converts an integer to a thickness, optionally using the converter parameter.</summary>
 public class IntToThicknessConverter : IValueConverter
 {
-    /// <summary>Gets an instance of <see cref="IntToThicknessConverter"/> that only sets the bottom side of the thickness.</summary>
+    /// <summary>Gets a converter that sets only the bottom side.</summary>
     public static IntToThicknessConverter BottomOnly { get; } = new() { Bottom = true };
 
-    /// <summary>Gets an instance of <see cref="IntToThicknessConverter"/> that only sets the left side of the thickness.</summary>
+    /// <summary>Gets a converter that sets only the left side.</summary>
     public static IntToThicknessConverter LeftOnly { get; } = new() { Left = true };
 
-    /// <summary>Gets an instance of <see cref="IntToThicknessConverter"/> that only sets the right side of the thickness.</summary>
+    /// <summary>Gets a converter that sets only the right side.</summary>
     public static IntToThicknessConverter RightOnly { get; } = new() { Right = true };
 
-    /// <summary>Gets an instance of <see cref="IntToThicknessConverter"/> that only sets the top side of the thickness.</summary>
+    /// <summary>Gets a converter that sets only the top side.</summary>
     public static IntToThicknessConverter TopOnly { get; } = new() { Top = true };
 
     /// <summary>Gets or sets a value indicating whether this <see cref="IntToThicknessConverter"/> is bottom.</summary>
@@ -79,5 +79,9 @@ public class IntToThicknessConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/InvertSignConverter.cs
+++ b/src/XamlConverters/InvertSignConverter.cs
@@ -12,10 +12,12 @@ namespace CP.Xaml.Converters;
 public class InvertSignConverter : IValueConverter
 {
     /// <summary>The message used when a value is not a supported numeric type.</summary>
-    private const string InvalidValueMessage = "The bound value is not a short, integer, float, double, or decimal.";
+    private const string InvalidValueMessage =
+        "The bound value is not a short, integer, float, double, or decimal.";
 
     /// <summary>The message used when a target is not a supported numeric type.</summary>
-    private const string InvalidTargetMessage = "The target type is not short, integer, float, double, decimal, or string.";
+    private const string InvalidTargetMessage =
+        "The target type is not short, integer, float, double, decimal, or string.";
 
     /// <summary>Converts the specified value.</summary>
     /// <param name="value">The value.</param>
@@ -26,7 +28,8 @@ public class InvertSignConverter : IValueConverter
     /// <exception cref="InvalidCastException">
     /// The value bounded is not of a integer, float or double.
     /// </exception>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => Invert(value, targetType, culture);
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        Invert(value, targetType, culture);
 
     /// <summary>Converts the back.</summary>
     /// <param name="value">The value.</param>
@@ -35,7 +38,11 @@ public class InvertSignConverter : IValueConverter
     /// <param name="culture">The culture.</param>
     /// <returns>original value.</returns>
     /// <exception cref="InvalidCastException">The value or target type is unsupported.</exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Invert(value, targetType, culture);
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Invert(value, targetType, culture);
 
     /// <summary>Inverts a supported numeric value and converts it to the requested target type.</summary>
     /// <param name="value">The value to invert.</param>

--- a/src/XamlConverters/IsGreaterThanOrEqualToConverter.cs
+++ b/src/XamlConverters/IsGreaterThanOrEqualToConverter.cs
@@ -56,7 +56,10 @@ public class IsGreaterThanOrEqualToConverter : IValueConverter, IMultiValueConve
     /// </returns>
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
-        if (values is null || values.Length < 2 || !values.All(x => x != DependencyProperty.UnsetValue))
+        if (
+            values is null
+            || values.Length < 2
+            || !values.All(x => x != DependencyProperty.UnsetValue))
         {
             return false;
         }
@@ -73,7 +76,11 @@ public class IsGreaterThanOrEqualToConverter : IValueConverter, IMultiValueConve
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 
     /// <summary>Converts a binding target value to the source binding values.</summary>
     /// <param name="value">The value that the binding target produces.</param>
@@ -86,5 +93,9 @@ public class IsGreaterThanOrEqualToConverter : IValueConverter, IMultiValueConve
     /// <returns>
     /// An array of values that have been converted from the target value back to the source values.
     /// </returns>
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => [value];
+    public object[] ConvertBack(
+        object value,
+        Type[] targetTypes,
+        object parameter,
+        CultureInfo culture) => [value];
 }

--- a/src/XamlConverters/Layout/PercentageConverter.cs
+++ b/src/XamlConverters/Layout/PercentageConverter.cs
@@ -7,11 +7,11 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Multiplies a numeric value by the percentage supplied in the parameter. Parameter may be '50%' or '0.5'.</summary>
+/// <summary>Multiplies a numeric value by a percentage parameter such as '50%' or '0.5'.</summary>
 public sealed class PercentageConverter : IValueConverter
 {
     /// <summary>The divisor used to convert a percentage to a factor.</summary>
-    private const double PercentageDivisor = 100d;
+    private const double PercentageDivisor = 100D;
 
     /// <summary>Applies the percentage factor.</summary>
     /// <param name="value">The value produced by the binding source.</param>
@@ -25,7 +25,7 @@ public sealed class PercentageConverter : IValueConverter
     {
         if (value is null || parameter is null)
         {
-            return 0d;
+            return 0D;
         }
 
         var baseVal = System.Convert.ToDouble(value, culture);
@@ -42,7 +42,7 @@ public sealed class PercentageConverter : IValueConverter
         }
         else
         {
-            factor = double.TryParse(parmText, out var raw) ? raw : 1d;
+            factor = double.TryParse(parmText, out var raw) ? raw : 1D;
         }
 
         return baseVal * factor;
@@ -56,5 +56,9 @@ public sealed class PercentageConverter : IValueConverter
     /// <returns>
     /// A converted value. If the method returns null, the valid null value is used.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Layout/ThicknessUniformConverter.cs
+++ b/src/XamlConverters/Layout/ThicknessUniformConverter.cs
@@ -9,7 +9,8 @@ using System.Windows.Data;
 namespace CP.Xaml.Converters;
 
 /// <summary>
-/// Creates a uniform (or partially uniform) Thickness from a numeric value. Parameter tokens: L,R,T,B,H,V to enable specific sides.
+/// Creates a uniform (or partially uniform) Thickness from a numeric value. Parameter tokens: L,R,T,B,H,V to enable
+/// specific sides.
 /// Examples: parameter="LRT" sets Left/Right/Top only. Empty or null parameter sets all sides.
 /// </summary>
 public sealed class ThicknessUniformConverter : IValueConverter
@@ -76,5 +77,9 @@ public sealed class ThicknessUniformConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use (unused).</param>
     /// <param name="culture">The culture to use in the converter (unused).</param>
     /// <returns><see cref="Binding.DoNothing"/>.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/LineStrokeLevelConverter.cs
+++ b/src/XamlConverters/LineStrokeLevelConverter.cs
@@ -50,5 +50,9 @@ public class LineStrokeLevelConverter : IValueConverter
     /// <param name="parameter">The parameter.</param>
     /// <param name="culture">The culture.</param>
     /// <returns>A Value.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/MathConverter.cs
+++ b/src/XamlConverters/MathConverter.cs
@@ -40,7 +40,8 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => CallOtherConvert((object[])value, targetType, parameter, culture);
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        CallOtherConvert((object[])value, targetType, parameter, culture);
 
     /// <summary>
     /// Converts source values to a value for the binding target. The data binding engine calls
@@ -89,7 +90,11 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
     /// <exception cref="NotImplementedException">Not Implemented Exception.</exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 
     /// <summary>Converts a binding target value to the source binding values.</summary>
     /// <param name="value">The value that the binding target produces.</param>
@@ -103,7 +108,11 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
     /// An array of values that have been converted from the target value back to the source values.
     /// </returns>
     /// <exception cref="NotImplementedException">Not Implemented Exception.</exception>
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => [value];
+    public object[] ConvertBack(
+        object value,
+        Type[] targetTypes,
+        object parameter,
+        CultureInfo culture) => [value];
 
     /// <summary>
     /// When implemented in a derived class, returns an object that is provided as the value of
@@ -148,7 +157,9 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
 
         return targetType == typeof(long)
             ? (long)result
-            : throw new ArgumentException(string.Format("Unsupported target type {0}", targetType.FullName), nameof(targetType));
+            : throw new ArgumentException(
+                string.Format("Unsupported target type {0}", targetType.FullName),
+                nameof(targetType));
     }
 
     /// <summary>Calls the other convert.</summary>
@@ -157,7 +168,11 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
     /// <param name="parameter">The parameter.</param>
     /// <param name="culture">The culture.</param>
     /// <returns>new object.</returns>
-    private object CallOtherConvert(object[] values, Type targetType, object parameter, CultureInfo culture) => Convert(values, targetType, parameter, culture);
+    private object CallOtherConvert(
+        object[] values,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Convert(values, targetType, parameter, culture);
 
     /// <summary>Parses the specified s.</summary>
     /// <param name="s">The s.</param>
@@ -181,7 +196,8 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
     /// <param name="left">The left.</param>
     /// <param name="right">The right.</param>
     /// <exception cref="ArgumentException">Invalid operation + operation.</exception>
-    private sealed class BinaryOperation(char operation, IExpression left, IExpression right) : IExpression
+    private sealed class BinaryOperation(char operation, IExpression left, IExpression right)
+        : IExpression
     {
         /// <summary>The left.</summary>
         private readonly IExpression _left = left;
@@ -290,7 +306,11 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
             }
             catch (Exception ex)
             {
-                var msg = string.Format("MathConverter: error parsing expression '{0}'. {1} at position {2}", textToParse, ex.Message, _pos);
+                var msg = string.Format(
+                    "MathConverter: error parsing expression '{0}'. {1} at position {2}",
+                    textToParse,
+                    ex.Message,
+                    _pos);
                 throw new ArgumentException(msg, ex);
             }
         }
@@ -298,7 +318,8 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
         /// <summary>Gets the converter input index represented by a named variable.</summary>
         /// <param name="character">The variable character.</param>
         /// <param name="index">The positional converter input index.</param>
-        /// <returns><see langword="true"/> when the character is a named variable; otherwise, <see langword="false"/>.</returns>
+        /// <returns><see langword="true"/> when the character is a named variable; otherwise, <see langword="false"/>.
+        /// </returns>
         private static bool TryGetVariableIndex(char character, out int index)
         {
             index = character switch
@@ -438,7 +459,8 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
             var match = DecimalRegex.Match(_text!.Substring(_pos));
             if (!match.Success)
             {
-                throw new ArgumentException(string.Format("Unexpected character '{0}'", unexpectedCharacter));
+                throw new ArgumentException(
+                    string.Format("Unexpected character '{0}'", unexpectedCharacter));
             }
 
             _pos += match.Length;
@@ -533,7 +555,8 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
                 return;
             }
 
-            throw new ArgumentException(string.Format("'{0}' is not a valid parameter index", text));
+            throw new ArgumentException(
+                string.Format("'{0}' is not a valid parameter index", text));
         }
 
         /// <summary>Initializes a new instance of the <see cref="Variable"/> class.</summary>
@@ -546,7 +569,11 @@ public class MathConverter : MarkupExtension, IMultiValueConverter, IValueConver
         /// <exception cref="ArgumentException">Argument Exception.</exception>
         public decimal Eval(object[] args) =>
             _index >= args.Length
-                ? throw new ArgumentException(string.Format("MathConverter: parameter index {0} is out of range. {1} parameter(s) supplied", _index, args.Length))
+                ? throw new ArgumentException(
+                    string.Format(
+                        "MathConverter: parameter index {0} is out of range. {1} parameter(s) supplied",
+                        _index,
+                        args.Length))
                 : System.Convert.ToDecimal(args[_index]);
     }
 }

--- a/src/XamlConverters/MultiConverter.cs
+++ b/src/XamlConverters/MultiConverter.cs
@@ -23,7 +23,10 @@ public class MultiConverter : List<IValueConverter>, IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => this.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, culture));
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        this.Aggregate(
+            value,
+            (current, converter) => converter.Convert(current, targetType, parameter, culture));
 
     /// <summary>Converts a value.</summary>
     /// <param name="value">The value that is produced by the binding target.</param>
@@ -31,5 +34,9 @@ public class MultiConverter : List<IValueConverter>, IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/NullCoalesceConverter.cs
+++ b/src/XamlConverters/NullCoalesceConverter.cs
@@ -34,5 +34,9 @@ public sealed class NullCoalesceConverter : IValueConverter
     /// <returns>
     /// Binding.DoNothing.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Number/NumberFormatConverter.cs
+++ b/src/XamlConverters/Number/NumberFormatConverter.cs
@@ -10,7 +10,7 @@ namespace CP.Xaml.Converters;
 /// <summary>Formats any built-in numeric value and parses the result back to the requested numeric type.</summary>
 public sealed class NumberFormatConverter : IValueConverter
 {
-    /// <summary>Formats a number using the optional standard or custom numeric format in the converter parameter.</summary>
+    /// <summary>Formats a number using an optional standard or custom format parameter.</summary>
     /// <param name="value">The numeric value.</param>
     /// <param name="targetType">The binding target type.</param>
     /// <param name="parameter">An optional format such as <c>N2</c>, <c>C</c>, or <c>0.###</c>.</param>
@@ -18,7 +18,10 @@ public sealed class NumberFormatConverter : IValueConverter
     /// <returns>The formatted number, or <see cref="Binding.DoNothing"/> for a nonnumeric value.</returns>
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is null || !BclConversion.IsNumericType(value.GetType()) || value is not IFormattable formattable)
+        if (
+            value is null
+            || !BclConversion.IsNumericType(value.GetType())
+            || value is not IFormattable formattable)
         {
             return Binding.DoNothing;
         }
@@ -39,7 +42,11 @@ public sealed class NumberFormatConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The culture used for parsing.</param>
     /// <returns>The parsed number, or <see cref="Binding.DoNothing"/> when parsing fails.</returns>
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    public object? ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture) =>
         BclConversion.IsNumericType(targetType)
         && BclConversion.TryChangeType(value, targetType, culture, out var result)
             ? result

--- a/src/XamlConverters/Resources/ConvertersDictionary.cs
+++ b/src/XamlConverters/Resources/ConvertersDictionary.cs
@@ -18,8 +18,9 @@ namespace CP.Xaml.Converters;
 public class ConvertersDictionary : ResourceDictionary
 {
     /// <summary>The pack URI of the shared converter resource dictionary.</summary>
-    private const string DictionaryUri = "pack://application:,,,/CP.Xaml.Converters;component/Resources/Converters.xaml";
+    private const string DictionaryUri =
+        "pack://application:,,,/CP.Xaml.Converters;component/Resources/Converters.xaml";
 
-    /// <summary>Initializes a new instance of the <see cref="ConvertersDictionary"/> class. Default constructor defining <see cref="ResourceDictionary.Source"/> of the <c>XamlConverters</c> Converters dictionary.</summary>
+    /// <summary>Initializes a new instance of the <see cref="ConvertersDictionary"/> class.</summary>
     public ConvertersDictionary() => Source = new(DictionaryUri, UriKind.Absolute);
 }

--- a/src/XamlConverters/Text/MultiStringFormatConverter.cs
+++ b/src/XamlConverters/Text/MultiStringFormatConverter.cs
@@ -15,24 +15,38 @@ namespace CP.Xaml.Converters;
 public sealed class MultiStringFormatConverter : IMultiValueConverter
 {
     /// <summary>
-    /// Converts source values to a value for the binding target. The data binding engine calls this method when it propagates the values from source bindings to the binding target.
+    /// Converts source values to a value for the binding target. The data binding engine calls this method when it
+    /// propagates the values from source bindings to the binding target.
     /// </summary>
-    /// <param name="values">The array of values that the source bindings in the <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to provide for conversion.</param>
+    /// <param name="values">The array of values that the source bindings in the
+    /// <see cref="T:System.Windows.Data.MultiBinding" /> produces. The value
+    /// <see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the source binding has no value to
+    /// provide for conversion.</param>
     /// <param name="targetType">The type of the binding target property.</param>
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>
-    /// A converted value.If the method returns null, the valid null value is used.A return value of <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" /> indicates that the converter did not produce a value, and that the binding will use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default value.A return value of <see cref="T:System.Windows.Data.Binding" />.<see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
+    /// A converted value.If the method returns null, the valid null value is used.A return value of
+    /// <see cref="T:System.Windows.DependencyProperty" />.<see cref="F:System.Windows.DependencyProperty.UnsetValue" />
+    /// indicates that the converter did not produce a value, and that the binding will use the
+    /// <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> if it is available, or else will use the default
+    /// value.A return value of <see cref="T:System.Windows.Data.Binding" />.
+    /// <see cref="F:System.Windows.Data.Binding.DoNothing" /> indicates that the binding does not transfer the value or
+    /// use the <see cref="P:System.Windows.Data.BindingBase.FallbackValue" /> or the default value.
     /// </returns>
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
         var format = parameter as string;
         if (string.IsNullOrEmpty(format))
         {
-            return string.Join(" ", values.Where(v => v != DependencyProperty.UnsetValue && v is not null));
+            return string.Join(
+                " ",
+                values.Where(v => v != DependencyProperty.UnsetValue && v is not null));
         }
 
-        var safeValues = values.Select(v => v == DependencyProperty.UnsetValue ? null : v).ToArray();
+        var safeValues = values
+            .Select(v => v == DependencyProperty.UnsetValue ? null : v)
+            .ToArray();
         try
         {
             return string.Format(culture, format, safeValues);
@@ -45,11 +59,16 @@ public sealed class MultiStringFormatConverter : IMultiValueConverter
 
     /// <summary>Converts a binding target value to the source binding values.</summary>
     /// <param name="value">The value that the binding target produces.</param>
-    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of values that are suggested for the method to return.</param>
+    /// <param name="targetTypes">The array of types to convert to. The array length indicates the number and types of
+    /// values that are suggested for the method to return.</param>
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>
     /// An array of values that have been converted from the target value back to the source values.
     /// </returns>
-    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => targetTypes.Select(_ => Binding.DoNothing).ToArray();
+    public object[] ConvertBack(
+        object value,
+        Type[] targetTypes,
+        object parameter,
+        CultureInfo culture) => targetTypes.Select(_ => Binding.DoNothing).ToArray();
 }

--- a/src/XamlConverters/ToLowerConverter.cs
+++ b/src/XamlConverters/ToLowerConverter.cs
@@ -16,7 +16,8 @@ public class ToLowerConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value?.ToString()?.ToLowerInvariant() ?? string.Empty;
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value?.ToString()?.ToLowerInvariant() ?? string.Empty;
 
     /// <summary>Converts a value.</summary>
     /// <param name="value">The value that is produced by the binding target.</param>
@@ -24,5 +25,9 @@ public class ToLowerConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/ToUpperConverter.cs
+++ b/src/XamlConverters/ToUpperConverter.cs
@@ -16,7 +16,8 @@ public class ToUpperConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value?.ToString()?.ToUpperInvariant() ?? string.Empty;
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value?.ToString()?.ToUpperInvariant() ?? string.Empty;
 
     /// <summary>Converts a value.</summary>
     /// <param name="value">The value that is produced by the binding target.</param>
@@ -25,5 +26,9 @@ public class ToUpperConverter : IValueConverter
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
     /// <exception cref="NotImplementedException">Not Implemented Exception.</exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/ValueGtXConverter.cs
+++ b/src/XamlConverters/ValueGtXConverter.cs
@@ -32,7 +32,8 @@ public class ValueGtXConverter : IValueConverter
         }
 
         var val = (double)value;
-        var comparator = parameter is string ? double.Parse(parameter.ToString()!) : (double)parameter!;
+        var comparator =
+            parameter is string ? double.Parse(parameter.ToString()!) : (double)parameter!;
         return Math.Round(val, val > comparator ? 1 : DefaultPrecision);
     }
 
@@ -42,5 +43,9 @@ public class ValueGtXConverter : IValueConverter
     /// <param name="parameter">The converter parameter.</param>
     /// <param name="culture">The conversion culture.</param>
     /// <returns>The WPF do-nothing binding sentinel.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/ValueToBrushConverter.cs
+++ b/src/XamlConverters/ValueToBrushConverter.cs
@@ -19,26 +19,26 @@ public class ValueToBrushConverter : IValueConverter
     /// <returns>Gets the brush colour from a value greater than zero.</returns>
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        var val = 0d;
+        var val = 0D;
         switch (value)
         {
             case float x:
-                {
-                    val = x;
-                    break;
-                }
+            {
+                val = x;
+                break;
+            }
 
             case double x2:
-                {
-                    val = x2;
-                    break;
-                }
+            {
+                val = x2;
+                break;
+            }
 
             case bool x3:
-                {
-                    val = x3 ? 0 : 1;
-                    break;
-                }
+            {
+                val = x3 ? 0 : 1;
+                break;
+            }
         }
 
         var parameterText = parameter?.ToString();
@@ -46,16 +46,16 @@ public class ValueToBrushConverter : IValueConverter
         {
             if (parameterText!.Contains("BackPressure"))
             {
-                return val > 0d ? Brushes.DarkBlue : Brushes.LightYellow;
+                return val > 0D ? Brushes.DarkBlue : Brushes.LightYellow;
             }
 
             if (parameterText.Contains("Pressure"))
             {
-                return val > 0d ? Brushes.Black : Brushes.LightYellow;
+                return val > 0D ? Brushes.Black : Brushes.LightYellow;
             }
         }
 
-        return val > 0d ? Brushes.DarkGreen : Brushes.LightYellow;
+        return val > 0D ? Brushes.DarkGreen : Brushes.LightYellow;
     }
 
     /// <summary>Converts the back.</summary>
@@ -64,5 +64,9 @@ public class ValueToBrushConverter : IValueConverter
     /// <param name="parameter">The parameter.</param>
     /// <param name="culture">The culture.</param>
     /// <returns>A Value.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Visibility/BoolToVisibilityConverter.cs
+++ b/src/XamlConverters/Visibility/BoolToVisibilityConverter.cs
@@ -8,7 +8,7 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Value converter that translates true to <see cref="Visibility.Visible"/> and false to <see cref="Visibility.Collapsed"/>.</summary>
+/// <summary>Converts true to visible and false to collapsed.</summary>
 public sealed class BoolToVisibilityConverter : IValueConverter
 {
     /// <summary>Converts a value.</summary>

--- a/src/XamlConverters/Visibility/BoolToVisibilityConverterNegate.cs
+++ b/src/XamlConverters/Visibility/BoolToVisibilityConverterNegate.cs
@@ -11,7 +11,7 @@ namespace CP.Xaml.Converters;
 /// <summary>Boolean to Visibility Converter.</summary>
 public class BoolToVisibilityConverterNegate : IValueConverter
 {
-    /// <summary>Enable the visibility of the UI element in base of a boolean value (true---&gt;Collapsed//false--&gt;Visible).</summary>
+    /// <summary>Converts true to collapsed and false to visible.</summary>
     /// <param name="value">The value.</param>
     /// <param name="targetType">Type of the target.</param>
     /// <param name="parameter">The parameter.</param>
@@ -48,9 +48,14 @@ public class BoolToVisibilityConverterNegate : IValueConverter
     /// <param name="culture">The culture.</param>
     /// <returns>A Value.</returns>
     /// <exception cref="InvalidCastException">The bound value back is not of type Visibility.</exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => value switch
-    {
-        Visibility val => (object)(val != Visibility.Visible),
-        _ => throw new InvalidCastException("The bound value back is not of type Visibility"),
-    };
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) =>
+        value switch
+        {
+            Visibility val => (object)(val != Visibility.Visible),
+            _ => throw new InvalidCastException("The bound value back is not of type Visibility"),
+        };
 }

--- a/src/XamlConverters/Visibility/IntToVisibilityConverter.cs
+++ b/src/XamlConverters/Visibility/IntToVisibilityConverter.cs
@@ -12,7 +12,7 @@ namespace CP.Xaml.Converters;
 /// <seealso cref="System.Windows.Data.IValueConverter"/>
 public class IntToVisibilityConverter : IValueConverter
 {
-    /// <summary>Enable the visibility of the UI element in base of a boolean value (true---&gt;visible//false--&gt;Collapsed).</summary>
+    /// <summary>Converts a positive integer to visible and other values to collapsed.</summary>
     /// <param name="value">The value.</param>
     /// <param name="targetType">Type of the target.</param>
     /// <param name="parameter">The parameter.</param>

--- a/src/XamlConverters/Visibility/NullToVisibilityConverter.cs
+++ b/src/XamlConverters/Visibility/NullToVisibilityConverter.cs
@@ -36,5 +36,9 @@ public class NullToVisibilityConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Visibility/StringNullOrEmptyToVisibilityConverter.cs
+++ b/src/XamlConverters/Visibility/StringNullOrEmptyToVisibilityConverter.cs
@@ -51,5 +51,9 @@ public sealed class StringNullOrEmptyToVisibilityConverter : IValueConverter
     /// <returns>
     /// Binding.DoNothing.
     /// </returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Visibility/ValueNotNullToVisibilityConverter.cs
+++ b/src/XamlConverters/Visibility/ValueNotNullToVisibilityConverter.cs
@@ -8,7 +8,7 @@ using System.Windows.Data;
 
 namespace CP.Xaml.Converters;
 
-/// <summary>Value converter that translates true to <see cref="Visibility.Visible"/> and false to <see cref="Visibility.Collapsed"/>.</summary>
+/// <summary>Converts a non-null value to visible and a null value to collapsed.</summary>
 public sealed class ValueNotNullToVisibilityConverter : IValueConverter
 {
     /// <summary>Converts a value.</summary>
@@ -38,5 +38,9 @@ public sealed class ValueNotNullToVisibilityConverter : IValueConverter
     /// <exception cref="NotImplementedException">
     /// The method or operation is not implemented.
     /// </exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Visibility/VisibilityFromNumberConverter.cs
+++ b/src/XamlConverters/Visibility/VisibilityFromNumberConverter.cs
@@ -33,5 +33,9 @@ public sealed class VisibilityFromNumberConverter : IValueConverter
     /// <param name="parameter">The converter parameter to use.</param>
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Visibility/VisibilityFromNumberEqualsConverter.cs
+++ b/src/XamlConverters/Visibility/VisibilityFromNumberEqualsConverter.cs
@@ -34,5 +34,9 @@ public sealed class VisibilityFromNumberEqualsConverter : IValueConverter
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
     /// <exception cref="Exception">The method or operation is not implemented.</exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }

--- a/src/XamlConverters/Visibility/ZeroToVisibilityConverter.cs
+++ b/src/XamlConverters/Visibility/ZeroToVisibilityConverter.cs
@@ -31,5 +31,9 @@ public class ZeroToVisibilityConverter : IValueConverter
     /// <param name="culture">The culture to use in the converter.</param>
     /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
     /// <exception cref="NotImplementedException">Not Implemented Exception.</exception>
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+    public object ConvertBack(
+        object value,
+        Type targetType,
+        object parameter,
+        CultureInfo culture) => Binding.DoNothing;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is dependency maintenance and build-quality cleanup. It updates `NuGet.Packaging` from 6.12.5 to 6.14.3 and `StyleSharp.Analyzers` from 3.20.0 to 3.21.10, then resolves the diagnostics exposed by the analyzer update in the WPF, Avalonia, and TUnit projects.

The source changes wrap long code and XML documentation, separate compound read/write increments, place a parser constant in its correct scope, and normalize analyzer-required style. No warning suppressions or analyzer-severity changes are introduced.

## What is the new behavior?

The complete solution builds cleanly with warnings treated as errors after the package updates. Converter behavior and public APIs are unchanged; the analyzer findings are corrected directly in source.

## What is the current behavior?

Updating StyleSharp exposes 288 unique diagnostics across 142 files: 284 `SST1521` long-line diagnostics, three `SST2015` compound read/write diagnostics, and one `SST1498` misplaced-constant diagnostic. These diagnostics prevent the strict CI build from remaining green.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation completed locally:

- Strict serialized Release build with `-warnaserror`: 0 warnings, 0 errors.
- Nuke `Compile --configuration Release`: 0 warnings, 0 errors.
- TUnit/Microsoft Testing Platform: 524/524 tests passed across 12 target frameworks, with no failures or skips.
- Merged coverage: 36.12% lines (2,041/5,650) and 24.69% branches (994/4,026).
- Restore and vulnerable/deprecated-package audits are clean.
- No `NoWarn`, warning pragmas, `SuppressMessage`, `GlobalSuppressions`, or analyzer-severity changes were added.

The 148-file diff is primarily analyzer-required formatting and XML documentation wrapping; no public API or intended runtime behavior changes are included.
